### PR TITLE
Fix links to examples in README

### DIFF
--- a/pointerevents/README.md
+++ b/pointerevents/README.md
@@ -1,8 +1,8 @@
 Examples:
 
-* [Drawing program](https://mdn.github.com/pointerevents/Using_Pointer_Events.html). This application is a Pointer Events version of the [Touch Events drawing program](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events). The application is described in [Using Pointer Events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events/Using_Pointer_Events).
-* [Multi-touch interaction demo](http://mdn.github.io/pointerevents/Multi-touch_interaction.html). This interactive demo shows how to use Pointer Events for mulit-touch interaction. The application is described in [Multi-touch interaction](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events/Multi-touch_interaction).
-* [Two-pointer Pinch/Zoom Demo](http://mdn.github.io/pointerevents/Pinch_zoom_gestures.html). This interactive demo shows how to recognize a simple two-pointer pinch/zoom gesture. The application is described in [Pinch zoom gestures](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events/Pinch_zoom_gestures).
+* [Drawing program](https://mdn.github.com/dom-examples/pointerevents/Using_Pointer_Events.html). This application is a Pointer Events version of the [Touch Events drawing program](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events). The application is described in [Using Pointer Events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events/Using_Pointer_Events).
+* [Multi-touch interaction demo](http://mdn.github.io/dom-examples/pointerevents/Multi-touch_interaction.html). This interactive demo shows how to use Pointer Events for mulit-touch interaction. The application is described in [Multi-touch interaction](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events/Multi-touch_interaction).
+* [Two-pointer Pinch/Zoom Demo](http://mdn.github.io/dom-examples/pointerevents/Pinch_zoom_gestures.html). This interactive demo shows how to recognize a simple two-pointer pinch/zoom gesture. The application is described in [Pinch zoom gestures](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events/Pinch_zoom_gestures).
 
 External Pointer Events Demos:
 


### PR DESCRIPTION
https\://mdn.github.com/pointerevents/… → https\://mdn.github.com/**dom-examples**/pointerevents/…