### PR TITLE
Corrected display of JS-object in HTML by using JSON.stringify

### DIFF
--- a/web-storage/event.js
+++ b/web-storage/event.js
@@ -1,7 +1,7 @@
-window.addEventListener('storage', function(e) {  
+window.addEventListener('storage', function(e) {
   document.querySelector('.my-key').textContent = e.key;
   document.querySelector('.my-old').textContent = e.oldValue;
   document.querySelector('.my-new').textContent = e.newValue;
   document.querySelector('.my-url').textContent = e.url;
-  document.querySelector('.my-storage').textContent = e.storageArea;
+  document.querySelector('.my-storage').textContent = JSON.stringify(e.storageArea);
 });


### PR DESCRIPTION
without JSON stringify, the display is [Object Storage] in the HTML display