### PR TITLE
Payment Request examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 * The "media" directory contains examples and demos showing how to use HTML and DOM [media elements and APIs](https://developer.mozilla.org/en-US/docs/Web/Media).
 
+* The "payment-request" directory contains examples of the Payment Request API.
+
 * The "performance-apis" directory is for examples and demos of the [Web Performance APIs](https://www.w3.org/wiki/Web_Performance/Publications).
 
 * The "pointerevents" directory is for examples and demos of the [Pointer Events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events) standard.

--- a/payment-request/README.md
+++ b/payment-request/README.md
@@ -1,0 +1,15 @@
+Examples:
+
+* [Feature Detect Support](feature-detect-support.html). Demonstrates using PaymentRequest if it is supported, otherwise falling back to a legacy web form.
+* [Customizing Button Depending on Whether User Can Make Payments](customize-button-can-make-payment.html). Demonstrates changing the title of the checkout button depending on whether the user can make a fast payment or they need to add payment credentials first.
+* [Recommend Payment App when User Has No Apps](recommend-payment-app.html). Demonstrates redirecting to a signup page for a payment app when the payment method is not supported.
+* [Check User Can Make Payment Before All Prices Known](check-user-can-make-payment.html). Demonstrates checking the user can make a payment before the line items and their prices are known, using `.canMakePayment()` with dummy data.
+* [Show Additional User Interface After Successful Payment](show-additional-ui-after-payment.html). Demonstrates showing another page for additional information collection, after the checkout.
+* [Pre-authorize Transaction](pre-authorize-transaction.html). Indicates how a Payment Handler could be used to return an authorization status, subject to the specification at the time of writing.
+
+External Examples:
+
+* [Payment Request Samples](https://googlechrome.github.io/samples/paymentrequest/) from Google
+* [Payment Request Codelab](https://codelabs.developers.google.com/codelabs/payment-request-api/#0) from Google
+* [VeggieShop](https://github.com/pjbazin/wpwg-demo) e-commerce website demo and source code
+* [WhiteCollar](https://github.com/pjbazin/wpwg-demo/tree/master/WhiteCollar) web payment app demo and source code

--- a/payment-request/check-user-can-make-payment.html
+++ b/payment-request/check-user-can-make-payment.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang=en>
 <head>
+  <meta charset="UTF-8">
   <title>Check Whether User Can Make Payment Before All Prices Are Known</title>
   <!--
     If the checkout flow needs to know whether `PaymentRequest.canMakePayment()` will 
@@ -69,7 +70,7 @@
       var shouldCallPaymentRequest = true;
 
       // Make a dummy payment request to check if user can make payment
-      new PaymentRequest(supportedPaymentMethods,
+      new PaymentRequest(buildSupportedPaymentMethodData(),
           {total: {label: 'Stub', amount: {currency: 'USD', value: '0.01'}}})
         .canMakePayment()
         .then(function(result) {
@@ -83,7 +84,16 @@
 
       checkoutButton.addEventListener('click', function() {
         callServerToRetrieveCheckoutDetails();
-      }
+      });
+
+    } else {
+
+      checkoutButton.addEventListener('click', function() {
+        // For demo purposes
+        introPanel.style.display = 'none';
+        legacyPanel.style.display = 'block';
+      });
+
     }
  
     function callServerToRetrieveCheckoutDetails() {
@@ -104,10 +114,12 @@
 
         request.show().then(function(paymentResponse) {
           // Here we would process the payment. For this demo, simulate immediate success:
-          paymentResponse.complete('success');
-          // For demo purposes:
-          introPanel.style.display = 'none';
-          successPanel.style.display = 'block';
+          paymentResponse.complete('success')
+            .then(function() {
+              // For demo purposes:
+              introPanel.style.display = 'none';
+              successPanel.style.display = 'block';
+            });
 
         }).catch(function(error) {
           // Handle cancelled/failed payment. Fall back to legacy form. For demo purposes:

--- a/payment-request/check-user-can-make-payment.html
+++ b/payment-request/check-user-can-make-payment.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <title>Check Whether User Can Make Payment Before All Prices Are Known</title>
+  <!--
+    If the checkout flow needs to know whether `PaymentRequest.canMakePayment()` will 
+    return true even before all line items and their prices are known, then you can 
+    instantiate PaymentRequest with dummy data and pre-query `.canMakePayment()`.
+    
+    If you call `.canMakePayment()` multiple times, keep in mind that the first parameter 
+    to the PaymentRequest constructor should contain the same method names and data.
+  -->
+  <meta name="viewport" content="width=device-width">
+  <style>
+    #success,
+    #legacy {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Check Whether User Can Make Payment Before All Prices Are Known</h1>
+
+  <div id="intro">
+    <p>
+      If the checkout flow needs to know whether <code>PaymentRequest.canMakePayment()</code> 
+      will return true even before all line items and their prices are known, then you can 
+      instantiate PaymentRequest with dummy data and pre-query <code>.canMakePayment()</code>. 
+    </p>
+    <p>
+      If you call <code>.canMakePayment()</code> multiple times, keep in mind that the first 
+      parameter to the PaymentRequest constructor should contain the same method names and data.
+    </p>      
+    <p>
+      Please note that no payments will be taken, this is just a front-end demo. 
+      If you would like to try entering card details, you can use dummy data,
+      for example the card number <code>4111 1111 1111 1111</code>.
+    </p>
+
+    <button id="checkout-button">Checkout</button>
+  </div>
+  
+  <div id="success">
+    <p>
+      Payment Request success. Demo complete. No payment has been taken.
+    </p>
+  </div>
+
+  <div id="legacy">
+    <p>
+      The Payment Request API is unsupported or was cancelled or failed, 
+      so here we can proceed with our legacy web form (not implemented for this demo).
+    </p>
+  </div>
+
+  <script type="text/javascript">
+    
+    var checkoutButton = document.getElementById('checkout-button');
+    var introPanel = document.getElementById('intro');
+    var successPanel = document.getElementById('success');
+    var legacyPanel = document.getElementById('legacy');
+
+    // Feature detection
+    if (window.PaymentRequest) {
+
+      // Payment Request is supported in this browser, so we can proceed to use it
+
+      var shouldCallPaymentRequest = true;
+
+      // Make a dummy payment request to check if user can make payment
+      new PaymentRequest(supportedPaymentMethods,
+          {total: {label: 'Stub', amount: {currency: 'USD', value: '0.01'}}})
+        .canMakePayment()
+        .then(function(result) {
+          shouldCallPaymentRequest = result;
+        }).catch(function(error) {
+          console.log(error);
+          // The user may have turned off query ability in their privacy settings.
+          // Let's use PaymentRequest by default & fallback to legacy web form checkout.
+          shouldCallPaymentRequest = true;
+        });
+
+      checkoutButton.addEventListener('click', function() {
+        callServerToRetrieveCheckoutDetails();
+      }
+    }
+ 
+    function callServerToRetrieveCheckoutDetails() {
+      // Here we would call to the server with the chosen line items, to retrieve
+      // a `Checkout` object with all of the prices and shipping options.
+      // But for the purposes of this demo, we will skip that and proceed immediately.    
+      onServerCheckoutDetailsRetrieved(buildShoppingCartDetails());
+    }
+
+    function onServerCheckoutDetailsRetrieved(checkoutObject) {
+      // The server has constructed the `Checkout` object. Now we know all of the prices 
+      // and shipping options.
+
+      if (shouldCallPaymentRequest) {
+
+        var request = new PaymentRequest(buildSupportedPaymentMethodData(),
+          checkoutObject);
+
+        request.show().then(function(paymentResponse) {
+          // Here we would process the payment. For this demo, simulate immediate success:
+          paymentResponse.complete('success');
+          // For demo purposes:
+          introPanel.style.display = 'none';
+          successPanel.style.display = 'block';
+
+        }).catch(function(error) {
+          // Handle cancelled/failed payment. Fall back to legacy form. For demo purposes:
+          introPanel.style.display = 'none';
+          legacyPanel.style.display = 'block';
+        });
+
+      } else {
+        // Fall back to legacy form. (We could redirect, but) for demo purposes:
+        introPanel.style.display = 'none';
+        legacyPanel.style.display = 'block';
+      }
+
+    }
+
+    function buildSupportedPaymentMethodData() {
+      // Example supported payment methods:
+      return [{
+        supportedMethods: 'basic-card',
+        data: {
+          supportedNetworks: ['visa', 'mastercard'],
+          supportedTypes: ['debit', 'credit']
+        }
+      }];
+    }
+
+    function buildShoppingCartDetails() {
+      // Hardcoded for demo purposes:
+      return {
+        id: 'order-123',
+        displayItems: [
+          {
+            label: 'Example item',
+            amount: {currency: 'USD', value: '1.00'}
+          }
+        ],
+        total: {
+          label: 'Total',
+          amount: {currency: 'USD', value: '1.00'}
+        },
+        shippingOptions: [
+          {  
+            id: 'example-shipping',
+            label: 'Example Shipping (2-3 Days)',
+            amount: {currency: 'USD', value: '0.50'}
+          }
+        ]
+      };
+    }
+  </script>
+</body>
+</html>

--- a/payment-request/customize-button-can-make-payment.html
+++ b/payment-request/customize-button-can-make-payment.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang=en>
 <head>
+  <meta charset="UTF-8">
   <title>Customize the Payment Request Button Depending on Whether User Can Make Payments</title>
   <!--
     Depending on whether the user can make a fast payment or needs to add payment credentials 
@@ -10,7 +11,7 @@
   <meta name="viewport" content="width=device-width">
   <style>
     #success,
-    #error {
+    #legacy {
       display: none;
     }
   </style>
@@ -23,7 +24,7 @@
     <p>
       In this example, depending on whether the user can make a fast payment or needs to add 
       payment credentials first, the title of the checkout button changes between 
-      "Checkout" and "Fast Checkout". This is determined using 
+      "W3C Checkout" and "Fast W3C Checkout". This is determined using 
       <code>PaymentRequest.canMakePayment()</code>. In both cases, the checkout button calls 
       <code>PaymentRequest.show()</code>.
     </p>
@@ -34,7 +35,7 @@
       for example the card number <code>4111 1111 1111 1111</code>.
     </p>
 
-    <button id="checkout-button">Loading...</button>
+    <button id="checkout-button">Checkout</button>
   </div>
   
   <div id="success">
@@ -43,7 +44,7 @@
     </p>
   </div>
 
-  <div id="error">
+  <div id="legacy">
     <p>
       The Payment Request API is unsupported or was cancelled or failed.
       Here we can proceed with a fallback (not implemented for this demo).
@@ -55,48 +56,55 @@
     var checkoutButton = document.getElementById('checkout-button');
     var introPanel = document.getElementById('intro');
     var successPanel = document.getElementById('success');
-    var errorPanel = document.getElementById('error');
+    var legacyPanel = document.getElementById('legacy');
 
     // Feature detection
     if (window.PaymentRequest) {
 
       // Payment Request is supported in this browser, so we can proceed to use it
 
-      var request = new PaymentRequest(buildSupportedPaymentMethodNames(),
+      var request = new PaymentRequest(buildSupportedPaymentMethodData(),
         buildShoppingCartDetails());
 
       request.canMakePayment().then(function(canMakeAFastPayment) {
         if (canMakeAFastPayment) {
-          checkoutButton.innerText = 'Fast Checkout';
+          checkoutButton.innerText = 'Fast W3C Checkout';
         } else {
-          checkoutButton.innerText = 'Checkout';
+          checkoutButton.innerText = 'W3C Checkout';
         }
       }).catch(function(error) {
         // The user may have turned off the querying functionality in their privacy settings. 
         // We do not know whether they can make a fast payment, so pick a generic title.
-        checkoutButton.innerText = 'Checkout';
+        checkoutButton.innerText = 'W3C Checkout';
       });
 
       checkoutButton.addEventListener('click', function() {
         
         request.show().then(function(paymentResponse) {
           // Here we would process the payment. For this demo, simulate immediate success:
-          paymentResponse.complete('success');
-          // For demo purposes:
-          introPanel.style.display = 'none';
-          successPanel.style.display = 'block';
+          paymentResponse.complete('success')
+            .then(function() {
+              // For demo purposes:
+              introPanel.style.display = 'none';
+              successPanel.style.display = 'block';
+            });
 
         }).catch(function(error) {
           // Handle cancelled or failed payment. For demo purposes:
           introPanel.style.display = 'none';
-          errorPanel.style.display = 'block';
+          legacyPanel.style.display = 'block';
 
         });        
       });
+
     } else {
-      // Payment Request is unsupported. For demo purposes:
-      introPanel.style.display = 'none';
-      errorPanel.style.display = 'block';
+
+      // Payment Request is unsupported
+      checkoutButton.addEventListener('click', function() {
+        // For demo purposes:
+        introPanel.style.display = 'none';
+        legacyPanel.style.display = 'block';
+      });
     }
 
     function buildSupportedPaymentMethodData() {

--- a/payment-request/customize-button-can-make-payment.html
+++ b/payment-request/customize-button-can-make-payment.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <title>Customize the Payment Request Button Depending on Whether User Can Make Payments</title>
+  <!--
+    Depending on whether the user can make a fast payment or needs to add payment credentials 
+    first, the title of the checkout button changes between "Fast Checkout with W3C" and 
+    "Setup W3C Checkout". In both cases, the checkout button calls PaymentRequest.show().
+  -->
+  <meta name="viewport" content="width=device-width">
+  <style>
+    #success,
+    #error {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Customize the Payment Request Button Depending on Whether User Can Make Payments</h1>
+
+  <div id="intro">
+    <p>
+      In this example, depending on whether the user can make a fast payment or needs to add 
+      payment credentials first, the title of the checkout button changes between 
+      "Checkout" and "Fast Checkout". This is determined using 
+      <code>PaymentRequest.canMakePayment()</code>. In both cases, the checkout button calls 
+      <code>PaymentRequest.show()</code>.
+    </p>
+    <p>
+      For the purposes of the demo, imagine you have chosen an item and
+      now you need to check out. Please note that no payments will be taken, this is just a 
+      front-end demo. If you would like to try entering card details, you can use dummy data,
+      for example the card number <code>4111 1111 1111 1111</code>.
+    </p>
+
+    <button id="checkout-button">Loading...</button>
+  </div>
+  
+  <div id="success">
+    <p>
+      Payment Request success. Demo complete. No payment has been taken.
+    </p>
+  </div>
+
+  <div id="error">
+    <p>
+      The Payment Request API is unsupported or was cancelled or failed.
+      Here we can proceed with a fallback (not implemented for this demo).
+    </p>
+  </div>
+
+  <script type="text/javascript">
+    
+    var checkoutButton = document.getElementById('checkout-button');
+    var introPanel = document.getElementById('intro');
+    var successPanel = document.getElementById('success');
+    var errorPanel = document.getElementById('error');
+
+    // Feature detection
+    if (window.PaymentRequest) {
+
+      // Payment Request is supported in this browser, so we can proceed to use it
+
+      var request = new PaymentRequest(buildSupportedPaymentMethodNames(),
+        buildShoppingCartDetails());
+
+      request.canMakePayment().then(function(canMakeAFastPayment) {
+        if (canMakeAFastPayment) {
+          checkoutButton.innerText = 'Fast Checkout';
+        } else {
+          checkoutButton.innerText = 'Checkout';
+        }
+      }).catch(function(error) {
+        // The user may have turned off the querying functionality in their privacy settings. 
+        // We do not know whether they can make a fast payment, so pick a generic title.
+        checkoutButton.innerText = 'Checkout';
+      });
+
+      checkoutButton.addEventListener('click', function() {
+        
+        request.show().then(function(paymentResponse) {
+          // Here we would process the payment. For this demo, simulate immediate success:
+          paymentResponse.complete('success');
+          // For demo purposes:
+          introPanel.style.display = 'none';
+          successPanel.style.display = 'block';
+
+        }).catch(function(error) {
+          // Handle cancelled or failed payment. For demo purposes:
+          introPanel.style.display = 'none';
+          errorPanel.style.display = 'block';
+
+        });        
+      });
+    } else {
+      // Payment Request is unsupported. For demo purposes:
+      introPanel.style.display = 'none';
+      errorPanel.style.display = 'block';
+    }
+
+    function buildSupportedPaymentMethodData() {
+      // Example supported payment methods:
+      return [{
+        supportedMethods: 'basic-card',
+        data: {
+          supportedNetworks: ['visa', 'mastercard'],
+          supportedTypes: ['debit', 'credit']
+        }
+      }];
+    }
+
+    function buildShoppingCartDetails() {
+      // Hardcoded for demo purposes:
+      return {
+        id: 'order-123',
+        displayItems: [
+          {
+            label: 'Example item',
+            amount: {currency: 'USD', value: '1.00'}
+          }
+        ],
+        total: {
+          label: 'Total',
+          amount: {currency: 'USD', value: '1.00'}
+        }
+      };
+    }
+  </script>
+</body>
+</html>

--- a/payment-request/feature-detect-support.html
+++ b/payment-request/feature-detect-support.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang=en>
 <head>
+  <meta charset="UTF-8">
   <title>Feature Detect Support for Payment Request API</title>
   <!--
     If the user's browser supports PaymentRequest, the merchant page updates 
@@ -67,10 +68,12 @@
 
         request.show().then(function(paymentResponse) {
           // Here we would process the payment. For this demo, simulate immediate success:
-          paymentResponse.complete('success');
-          // For demo purposes:
-          introPanel.style.display = 'none';
-          successPanel.style.display = 'block';
+          paymentResponse.complete('success')
+          .then(function() {
+              // For demo purposes:
+              introPanel.style.display = 'none';
+              successPanel.style.display = 'block';
+            });
 
         }).catch(function(error) {
           // Handle cancelled or failed payment. For demo purposes:

--- a/payment-request/feature-detect-support.html
+++ b/payment-request/feature-detect-support.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <title>Feature Detect Support for Payment Request API</title>
+  <!--
+    If the user's browser supports PaymentRequest, the merchant page updates 
+    the checkout button to use PaymentRequest instead of using legacy web forms.
+  -->
+  <meta name="viewport" content="width=device-width">
+  <style>
+    #success,
+    #legacy {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Feature Detect Support for Payment Request API</h1>
+
+  <div id="intro">
+    <p>
+      This example shows how a legacy checkout form can be replaced by 
+      a Payment Request - only for browsers that support it.
+    </p>      
+    <p>
+      For the purposes of the demo, imagine you have chosen an item and
+      now you need to check out.
+    </p>
+    <p>
+      Please note that no payments will be taken, this is just a front-end demo. 
+      If you would like to try entering card details, you can use dummy data,
+      for example the card number <code>4111 1111 1111 1111</code>.
+    </p>
+
+    <button id="checkout-button">Checkout</button>
+  </div>
+  
+  <div id="success">
+    <p>
+      Payment Request success. Demo complete. No payment has been taken.
+    </p>
+  </div>
+
+  <div id="legacy">
+    <p>
+      The Payment Request API is unsupported or was cancelled or failed, 
+      so here we can proceed with our legacy web form (not implemented for this demo).
+    </p>
+  </div>
+
+  <script type="text/javascript">
+    
+    var checkoutButton = document.getElementById('checkout-button');
+    var introPanel = document.getElementById('intro');
+    var successPanel = document.getElementById('success');
+    var legacyPanel = document.getElementById('legacy');
+
+    // Feature detection
+    if (window.PaymentRequest) {
+
+      // Payment Request is supported in this browser, so we can proceed to use it
+
+      checkoutButton.addEventListener('click', function() {
+        // Every click on the checkout button should use a new instance of PaymentRequest 
+        // object, because PaymentRequest.show() can be called only once per instance.
+        var request = new PaymentRequest(buildSupportedPaymentMethodData(),
+          buildShoppingCartDetails());
+
+        request.show().then(function(paymentResponse) {
+          // Here we would process the payment. For this demo, simulate immediate success:
+          paymentResponse.complete('success');
+          // For demo purposes:
+          introPanel.style.display = 'none';
+          successPanel.style.display = 'block';
+
+        }).catch(function(error) {
+          // Handle cancelled or failed payment. For demo purposes:
+          introPanel.style.display = 'none';
+          legacyPanel.style.display = 'block';
+
+        });        
+      });
+    } else {
+
+      // Payment Request is unsupported
+      checkoutButton.addEventListener('click', function() {
+        // For demo purposes:
+        introPanel.style.display = 'none';
+        legacyPanel.style.display = 'block';
+      });
+    }
+
+    function buildSupportedPaymentMethodData() {
+      // Example supported payment methods:
+      return [{
+        supportedMethods: 'basic-card',
+        data: {
+          supportedNetworks: ['visa', 'mastercard'],
+          supportedTypes: ['debit', 'credit']
+        }
+      }];
+    }
+
+    function buildShoppingCartDetails() {
+      // Hardcoded for demo purposes:
+      return {
+        id: 'order-123',
+        displayItems: [
+          {
+            label: 'Example item',
+            amount: {currency: 'USD', value: '1.00'}
+          }
+        ],
+        total: {
+          label: 'Total',
+          amount: {currency: 'USD', value: '1.00'}
+        }
+      };
+    }
+  </script>
+</body>
+</html>

--- a/payment-request/feature-detect-support.html
+++ b/payment-request/feature-detect-support.html
@@ -20,16 +20,14 @@
 
   <div id="intro">
     <p>
-      This example shows how a legacy checkout form can be replaced by 
-      a Payment Request - only for browsers that support it.
-    </p>      
-    <p>
-      For the purposes of the demo, imagine you have chosen an item and
-      now you need to check out.
+      This example shows how a legacy checkout form can be replaced by a Payment Request
+      - only for browsers that support it - using:
+      <code>if (window.PaymentRequest) { ... }</code>.
     </p>
     <p>
-      Please note that no payments will be taken, this is just a front-end demo. 
-      If you would like to try entering card details, you can use dummy data,
+      For the purposes of the demo, imagine you have chosen an item and now you need to
+      check out. Please note that no payments will be taken, this is just a front-end
+      demo. If you would like to try entering card details, you can use dummy data,
       for example the card number <code>4111 1111 1111 1111</code>.
     </p>
 

--- a/payment-request/pre-authorize-transaction.html
+++ b/payment-request/pre-authorize-transaction.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <title>Pre-authorize Transaction</title>
+  <!--
+    Some use cases (e.g. paying for fuel at a service station) involve pre-authorization 
+    of payment. One way to do this is through a Payment Handler (see the Payment Handler 
+    API). At time of writing, that specification includes a CanMakePayment that a Payment 
+    Handler could make use of to return authorization status.
+  -->
+  <meta name="viewport" content="width=device-width">
+  <style>
+    #success,
+    #legacy {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Pre-authorize Transaction</h1>
+
+  <div id="intro">
+    <p>
+        Some use cases (e.g., paying for fuel at a service station) involve 
+        pre-authorization of payment. One way to do this is through a Payment Handler 
+        (see the <a href="https://www.w3.org/TR/payment-handler/">Payment Handler API</a>). 
+        Currently that specification includes a <code>CanMakePayment</code> that a 
+        Payment Handler could make use of, to return authorization status.
+    </p>
+    
+    <button id="preauthorize-button">Pre-authorize</button>
+  </div>
+  
+  <div id="success">
+    <p>
+      Payment Request success. Demo complete. No payment has been taken.
+    </p>
+  </div>
+
+  <div id="legacy">
+    <p>
+      The Payment Request API is unsupported or was cancelled or failed, 
+      so here we can proceed with our legacy web form (not implemented for this demo).
+    </p>
+  </div>
+
+  <script type="text/javascript">
+    
+    var preauthorizeButton = document.getElementById('preauthorize-button');
+    var introPanel = document.getElementById('intro');
+    var successPanel = document.getElementById('success');
+    var legacyPanel = document.getElementById('legacy');
+
+    // Feature detection
+    if (window.PaymentRequest) {
+
+      // Payment Request is supported in this browser, so we can proceed to use it
+
+      preauthorizeButton.addEventListener('click', function() {
+        
+        var request = new PaymentRequest(buildSupportedPaymentMethodData(),
+          buildShoppingCartDetails());
+ 
+        /*
+         * The canMakePayment() event will be handled by the Payment Handler.
+         * The payment handler would include the following code:
+         * 
+         * self.addEventListener('canmakepayment', function(evt) {
+         *   // Pre-authorize here.
+         *   let preAuthSuccess = ...;
+         *   evt.respondWith(preAuthSuccess);
+         * });
+         */
+        request.canMakePayment().then(function(response) {
+          
+          if (res) {
+            // The payment handler has pre-authorized a transaction with some
+            // static amount (e.g. USD $1.00). For demo purposes:
+
+            
+          } else {
+            // Pre-authorization failed or payment handler not installed.
+            // For demo purposes:
+            introPanel.style.display = 'none';
+            legacyPanel.style.display = 'block';  
+          }
+
+        }).catch(function(error) {
+          // Cancellation or error. For demo purposes:
+          introPanel.style.display = 'none';
+          legacyPanel.style.display = 'block';
+        });        
+      });
+    } else {
+
+      // Payment Request is unsupported
+      preauthorizeButton.addEventListener('click', function() {
+        // For demo purposes:
+        introPanel.style.display = 'none';
+        legacyPanel.style.display = 'block';
+      });
+    }
+
+    function buildSupportedPaymentMethodData() {
+      // Example supported payment methods:
+      return [
+        {
+          supportedMethods: 'https://example.com/preauth'
+        }
+      ];
+    }
+
+    function buildShoppingCartDetails() {
+      // Hardcoded for demo purposes:
+      return {
+        id: 'order-123',
+        displayItems: [
+          {
+            label: 'Example item',
+            amount: {currency: 'USD', value: '1.00'}
+          }
+        ],
+        total: {
+          label: 'Total',
+          amount: {currency: 'USD', value: '1.00'}
+        }
+      };
+    }
+  </script>
+</body>
+</html>

--- a/payment-request/pre-authorize-transaction.html
+++ b/payment-request/pre-authorize-transaction.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang=en>
 <head>
+  <meta charset="UTF-8">
   <title>Pre-authorize Transaction</title>
   <!--
     Some use cases (e.g. paying for fuel at a service station) involve pre-authorization 
@@ -77,7 +78,8 @@
           if (res) {
             // The payment handler has pre-authorized a transaction with some
             // static amount (e.g. USD $1.00). For demo purposes:
-
+            introPanel.style.display = 'none';
+            successPanel.style.display = 'block';
             
           } else {
             // Pre-authorization failed or payment handler not installed.

--- a/payment-request/recommend-payment-app.html
+++ b/payment-request/recommend-payment-app.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <title>Recommend a Payment App when User Has No Apps</title>
   <!--
-    If you select to pay with TommyPay on this merchant page, it tries to call 
+    If you select to pay with BobPay on this merchant page, it tries to call 
     `PaymentRequest.show()`, while intercepting the NOT_SUPPORTED_ERR exception. If this 
-    payment method is not supported, it redirects to the signup page for TommyPay.
+    payment method is not supported, it redirects to the download page for BobPay.
   -->
   <meta name="viewport" content="width=device-width">
   <style>
@@ -22,10 +22,10 @@
 
   <div id="intro">
     <p>
-      In this example, if you select to pay with TommyPay on this merchant page, it tries to 
+      In this example, if you select to pay with BobPay on this merchant page, it tries to 
       call <code>PaymentRequest.show()</code>, while intercepting the 
       <code>NOT_SUPPORTED_ERR exception</code>. If this payment method is not supported, 
-      it redirects to the signup page for TommyPay.
+      it redirects to the download page for BobPay.
     </p>      
     <p>
       For the purposes of the demo, imagine you have chosen an item and
@@ -78,14 +78,13 @@
 
           if (error.code == DOMException.NOT_SUPPORTED_ERR) {
 
-            // TommyPay not supported. Redirect to the signup page for TommyPay.
-            // We pass the url to the current page as redirect_url to the signup page, so that 
-            // the signup page can redirect back to this page upon successful signup, so that 
-            // the checkout process can continue seamlessly.
+            // BobPay not currently supported. Usually we might now wish to redirect
+            // to a signup page and we could pass our current URL so it could redirect 
+            // (or link) back to this page afterwards. For this demo, we are just 
+            // redirecting to the BobPay download page.
 
             window.location.href =
-              'https://tommythorsen.github.io/webpayments-demo/payment-apps/tommypay/signup/?redirect_url=' +
-                encodeURI(window.location.href);
+              'https://bobpay.xyz/#download';
 
           } else {
             // Other kinds of errors; cancelled or failed payment. For demo purposes:
@@ -107,7 +106,7 @@
 
     function buildSupportedPaymentMethodData() {
       return [{
-        supportedMethods: 'https://tommypay.no/pay'
+        supportedMethods: 'https://emerald-eon.appspot.com/bobpay'
       }];
     }
 

--- a/payment-request/recommend-payment-app.html
+++ b/payment-request/recommend-payment-app.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <title>Recommend a Payment App when User Has No Apps</title>
+  <!--
+    If you select to pay with TommyPay on this merchant page, it tries to call 
+    `PaymentRequest.show()`, while intercepting the NOT_SUPPORTED_ERR exception. If this 
+    payment method is not supported, it redirects to the signup page for TommyPay.
+  -->
+  <meta name="viewport" content="width=device-width">
+  <style>
+    #success,
+    #legacy {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Recommend a Payment App when User Has No Apps</h1>
+
+  <div id="intro">
+    <p>
+      In this example, if you select to pay with TommyPay on this merchant page, it tries to 
+      call <code>PaymentRequest.show()</code>, while intercepting the 
+      <code>NOT_SUPPORTED_ERR exception</code>. If this payment method is not supported, 
+      it redirects to the signup page for TommyPay.
+    </p>      
+    <p>
+      For the purposes of the demo, imagine you have chosen an item and
+      now you need to check out.
+    </p>
+    
+    <button id="checkout-button">Checkout</button>
+  </div>
+  
+  <div id="error">
+    <p>
+      The Payment Request API is unsupported or was cancelled or failed.
+      Here we can proceed with a fallback (not implemented for this demo).
+    </p>
+  </div>
+
+  <script type="text/javascript">
+    
+    var checkoutButton = document.getElementById('checkout-button');
+    var introPanel = document.getElementById('intro');
+    var errorPanel = document.getElementById('error');
+
+    // Feature detection
+    if (window.PaymentRequest) {
+
+      // Payment Request is supported in this browser, so we can proceed to use it
+
+      checkoutButton.addEventListener('click', function() {
+
+        var request = new PaymentRequest(buildSupportedPaymentMethodNames(),
+          buildShoppingCartDetails());
+
+        request.show().then(function(paymentResponse) {
+          // Here we would process the payment. For this demo, simulate immediate success:
+          paymentResponse.complete('success');
+
+        }).catch(function(error) {
+
+          if (error.code == DOMException.NOT_SUPPORTED_ERR) {
+
+            // TommyPay not supported. Redirect to the signup page for TommyPay.
+            // We pass the url to the current page as redirect_url to the signup page, so that 
+            // the signup page can redirect back to this page upon successful signup, so that 
+            // the checkout process can continue seamlessly.
+
+            window.location.href =
+            'https://tommythorsen.github.io/webpayments-demo/payment-apps/tommypay/signup/?redirect_url=' +
+              encodeURI(window.location.href);
+
+          } else {
+            // Other kinds of errors; cancelled or failed payment. For demo purposes:
+            introPanel.style.display = 'none';
+            errorPanel.style.display = 'block';
+          }
+
+        });        
+      });
+    } else {
+      // Payment Request is unsupported. For demo purposes:
+      introPanel.style.display = 'none';
+      errorPanel.style.display = 'block';
+    }
+
+    function buildSupportedPaymentMethodData() {
+      return [{
+        supportedMethods: 'https://tommypay.no/pay'
+      }, {
+        supportedMethods: 'basic-card'
+      }];
+    }
+
+    function buildShoppingCartDetails() {
+      // Hardcoded for demo purposes:
+      return {
+        id: 'order-123',
+        displayItems: [
+          {
+            label: 'Example item',
+            amount: {currency: 'USD', value: '1.00'}
+          }
+        ],
+        total: {
+          label: 'Total',
+          amount: {currency: 'USD', value: '1.00'}
+        }
+      };
+    }
+  </script>
+</body>
+</html>

--- a/payment-request/recommend-payment-app.html
+++ b/payment-request/recommend-payment-app.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang=en>
 <head>
+  <meta charset="UTF-8">
   <title>Recommend a Payment App when User Has No Apps</title>
   <!--
     If you select to pay with TommyPay on this merchant page, it tries to call 
@@ -34,7 +35,13 @@
     <button id="checkout-button">Checkout</button>
   </div>
   
-  <div id="error">
+  <div id="success">
+    <p>
+      Payment Request success. Demo complete. No payment has been taken.
+    </p>
+  </div>  
+
+  <div id="legacy">
     <p>
       The Payment Request API is unsupported or was cancelled or failed.
       Here we can proceed with a fallback (not implemented for this demo).
@@ -45,7 +52,8 @@
     
     var checkoutButton = document.getElementById('checkout-button');
     var introPanel = document.getElementById('intro');
-    var errorPanel = document.getElementById('error');
+    var successPanel = document.getElementById('success');
+    var legacyPanel = document.getElementById('legacy');
 
     // Feature detection
     if (window.PaymentRequest) {
@@ -54,12 +62,17 @@
 
       checkoutButton.addEventListener('click', function() {
 
-        var request = new PaymentRequest(buildSupportedPaymentMethodNames(),
+        var request = new PaymentRequest(buildSupportedPaymentMethodData(),
           buildShoppingCartDetails());
 
         request.show().then(function(paymentResponse) {
           // Here we would process the payment. For this demo, simulate immediate success:
-          paymentResponse.complete('success');
+          paymentResponse.complete('success')
+            .then(function() {
+                // For demo purposes:
+                introPanel.style.display = 'none';
+                successPanel.style.display = 'block';
+              });
 
         }).catch(function(error) {
 
@@ -71,28 +84,30 @@
             // the checkout process can continue seamlessly.
 
             window.location.href =
-            'https://tommythorsen.github.io/webpayments-demo/payment-apps/tommypay/signup/?redirect_url=' +
-              encodeURI(window.location.href);
+              'https://tommythorsen.github.io/webpayments-demo/payment-apps/tommypay/signup/?redirect_url=' +
+                encodeURI(window.location.href);
 
           } else {
             // Other kinds of errors; cancelled or failed payment. For demo purposes:
             introPanel.style.display = 'none';
-            errorPanel.style.display = 'block';
+            legacyPanel.style.display = 'block';
           }
 
         });        
       });
     } else {
-      // Payment Request is unsupported. For demo purposes:
-      introPanel.style.display = 'none';
-      errorPanel.style.display = 'block';
+      
+      // Payment Request is unsupported
+      checkoutButton.addEventListener('click', function() {
+        // For demo purposes:
+        introPanel.style.display = 'none';
+        legacyPanel.style.display = 'block';
+      });
     }
 
     function buildSupportedPaymentMethodData() {
       return [{
         supportedMethods: 'https://tommypay.no/pay'
-      }, {
-        supportedMethods: 'basic-card'
       }];
     }
 

--- a/payment-request/show-additional-ui-after-payment.html
+++ b/payment-request/show-additional-ui-after-payment.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang=en>
 <head>
+  <meta charset="UTF-8">
   <title>Show Additional User Interface After Successful Payment</title>
   <!--
     If the merchant desires to collect additional information not part of the API 
@@ -14,6 +15,10 @@
     #legacy {
       display: none;
     }
+    textarea {
+      display: block;
+      margin: 1em 0;
+    }
   </style>
 </head>
 <body>
@@ -24,7 +29,7 @@
     <p>
       If the merchant desires to collect additional information not part of the API 
       (e.g., additional delivery instructions), the merchant can show a page with 
-      additional <input type="text"> fields after the checkout..
+      additional <code>&lt;input&gt;</code> fields after the checkout..
     </p>
     <p>
       For the purposes of the demo, imagine you have chosen an item and now you need to 
@@ -39,7 +44,7 @@
   
   <div id="additional-details">
     <label for="additional-delivery-instructions">Additional delivery instructions</label>
-    <input id="additional-delivery-instructions" type="text" value=""/>
+    <textarea id="additional-delivery-instructions" value=""></textarea>
     <button id="confirm-button">Confirm order</button>
   </div>
 
@@ -59,6 +64,7 @@
   <script type="text/javascript">
     
     var checkoutButton = document.getElementById('checkout-button');
+    var confirmButton = document.getElementById('confirm-button');
     var introPanel = document.getElementById('intro');
     var additionalDetailsPanel = document.getElementById('additional-details');
     var successPanel = document.getElementById('success');
@@ -80,6 +86,7 @@
           paymentResponse.complete('success')
             .then(function() {
               // Request additional shipping address details
+              introPanel.style.display = 'none';
               additionalDetailsPanel.style.display = 'block';
             });
 
@@ -94,7 +101,7 @@
 
       // Payment Request is unsupported
       checkoutButton.addEventListener('click', function() {
-        // For demo purposes:
+        // Here we would process the additional details. For demo purposes:
         introPanel.style.display = 'none';
         legacyPanel.style.display = 'block';
       });

--- a/payment-request/show-additional-ui-after-payment.html
+++ b/payment-request/show-additional-ui-after-payment.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <title>Show Additional User Interface After Successful Payment</title>
+  <!--
+    If the merchant desires to collect additional information not part of the API 
+    (e.g., additional delivery instructions), the merchant can show a page with 
+    additional <input type="text"> fields after the checkout.
+  -->
+  <meta name="viewport" content="width=device-width">
+  <style>
+    #additional-details,
+    #success,
+    #legacy {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Show Additional User Interface After Successful Payment</h1>
+
+  <div id="intro">
+    <p>
+      If the merchant desires to collect additional information not part of the API 
+      (e.g., additional delivery instructions), the merchant can show a page with 
+      additional <input type="text"> fields after the checkout..
+    </p>
+    <p>
+      For the purposes of the demo, imagine you have chosen an item and now you need to 
+      check out. Please note that no payments will be taken, this is just a front-end 
+      demo. If you would like to try entering card details, you can use dummy data,
+      for example the card number <code>4111 1111 1111 1111</code>.
+    </p>
+
+    <button id="checkout-button">Checkout</button>
+
+  </div>
+  
+  <div id="additional-details">
+    <label for="additional-delivery-instructions">Additional delivery instructions</label>
+    <input id="additional-delivery-instructions" type="text" value=""/>
+    <button id="confirm-button">Confirm order</button>
+  </div>
+
+  <div id="success">
+    <p>
+      Payment Request success. Demo complete. No payment has been taken.
+    </p>
+  </div>
+
+  <div id="legacy">
+    <p>
+      The Payment Request API is unsupported or was cancelled or failed, 
+      so here we can proceed with our legacy web form (not implemented for this demo).
+    </p>
+  </div>
+
+  <script type="text/javascript">
+    
+    var checkoutButton = document.getElementById('checkout-button');
+    var introPanel = document.getElementById('intro');
+    var additionalDetailsPanel = document.getElementById('additional-details');
+    var successPanel = document.getElementById('success');
+    var legacyPanel = document.getElementById('legacy');
+
+    // Feature detection
+    if (window.PaymentRequest) {
+
+      // Payment Request is supported in this browser, so we can proceed to use it
+
+      checkoutButton.addEventListener('click', function() {
+        // Every click on the checkout button should use a new instance of PaymentRequest 
+        // object, because PaymentRequest.show() can be called only once per instance.
+        var request = new PaymentRequest(buildSupportedPaymentMethodData(),
+          buildShoppingCartDetails());
+
+        request.show().then(function(paymentResponse) {
+          // Here we would process the payment. For this demo, simulate immediate success:
+          paymentResponse.complete('success')
+            .then(function() {
+              // Request additional shipping address details
+              additionalDetailsPanel.style.display = 'block';
+            });
+
+        }).catch(function(error) {
+          // Handle cancelled or failed payment. For demo purposes:
+          introPanel.style.display = 'none';
+          legacyPanel.style.display = 'block';
+
+        });        
+      });
+    } else {
+
+      // Payment Request is unsupported
+      checkoutButton.addEventListener('click', function() {
+        // For demo purposes:
+        introPanel.style.display = 'none';
+        legacyPanel.style.display = 'block';
+      });
+    }
+
+    confirmButton.addEventListener('click', function() {
+      // For demo purposes:
+      additionalDetailsPanel.style.display = 'none';
+      successPanel.style.display = 'block';
+    });
+
+    function buildSupportedPaymentMethodData() {
+      // Example supported payment methods:
+      return [{
+        supportedMethods: 'basic-card',
+        data: {
+          supportedNetworks: ['visa', 'mastercard'],
+          supportedTypes: ['debit', 'credit']
+        }
+      }];
+    }
+
+    function buildShoppingCartDetails() {
+      // Hardcoded for demo purposes:
+      return {
+        id: 'order-123',
+        displayItems: [
+          {
+            label: 'Example item',
+            amount: {currency: 'USD', value: '1.00'}
+          }
+        ],
+        total: {
+          label: 'Total',
+          amount: {currency: 'USD', value: '1.00'}
+        }
+      };
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Hi. As discussed here: https://github.com/w3c/payment-request-info/issues/4

This adds Payment Request examples, based on the code snippets from https://github.com/w3c/payment-request-info/wiki/CodeExamples

I hope it makes sense to start this PR review process, so people can add feedback here, although I have a few questions remaining related to Payment Handlers, please: 

* Sorry I am unfamiliar: will BobPay (the native app and/or the web app) need to whitelist the MDN domain to allow the Payment Request? (I've noticed the `supported_origins` [here](https://rsolomakhin.github.io/bobpay/payment-manifest.json), which is linked to [here](https://github.com/madmath/payment-request-show/blob/d02c2d61703aa706aa1bdc7355fb80474a8acd8d/bobpay/app.js)?)
* ~~(Possibly related...) I have tested that the 'Recommend a Payment App' demo works when I have the BobPay native Android app installed, but when I only have the web app version of the Payment Handler installed, it gives me the 'NOT_SUPPORTED_ERR` and redirects to the download page. I wonder what is missing to allow the web app to work too?~~ Sorry, scratch that. It's working in Chrome Canary.
* For the 'Pre-authorize Transaction' demo: are there any Payment Handler demos out there which implement this? Or we need to build one?

Thanks!