### PR TITLE
Update stream examples to current spec

### DIFF
--- a/streams/grayscale-png/index.html
+++ b/streams/grayscale-png/index.html
@@ -22,11 +22,15 @@
   // Retrieve its body as ReadableStream
   .then(response => response.body)
   // Create a gray-scaled PNG stream out of the original
-  .then(body => new Response(new ReadableStream(new GrayscalePNGSource(body))))
-  .then(newResponse => newResponse.blob())
+  .then(rs => rs.pipeThrough(new TransformStream(new GrayscalePNGTransformer())))
+  // Create a new response out of the stream
+  .then(rs => new Response(rs))
+  // Create an object URL for the response
+  .then(response => response.blob())
   .then(blob => URL.createObjectURL(blob))
+  // Update image
   .then(url => image.src = url)
-  .catch(err => console.error(err));
+  .catch(console.error);
 
 </script>
 </body>

--- a/streams/grayscale-png/png-lib.js
+++ b/streams/grayscale-png/png-lib.js
@@ -19,181 +19,154 @@ function paeth(a, b, c) {
 
 
 /**
- * A source of a ReadableStream to create a grayscale PNG.
+ * A transformer of a TransformStream to create a grayscale PNG.
  */
-class GrayscalePNGSource {
-  /**
-   * @param {ReadableStream} rs
-   */
-  constructor(rs) {
-    this._rs = rs;
+class GrayscalePNGTransformer {
+  constructor() {
     this._mode = 'magic';
   }
 
   /**
-   * @param {ReadableStreamDefaultController} controller
+   * Called for every downloaded PNG data chunk to be grayscaled.
+   *
+   * @param {Uint8Array} chunk The downloaded chunk.
+   * @param {TransformStreamDefaultController} controller The controller to euqueue grayscaled data.
    */
-  start(controller) {
-    const reader = this._rs.getReader();
-    this._pump(controller, reader, new Uint8Array(0)).then((value) => {
-      let position = value.byteOffset;
-      let length = value.byteLength;
-      const source = new DataView(value.buffer, position, length);
-      const buffer = new Uint8Array(length);
-      const target = new DataView(buffer.buffer, position, length);
+  transform(chunk, controller) {
+    let position = chunk.byteOffset;
+    let length = chunk.byteLength;
+    const source = new DataView(chunk.buffer, position, length);
+    const buffer = new Uint8Array(length);
+    const target = new DataView(buffer.buffer, position, length);
 
-      while (position < length) {
-        switch (this._mode) {
-          case 'magic': {
-            const magic1 = source.getUint32(position);
-            target.setUint32(position, magic1);
-            position += 4;
+    while (position < length) {
+      switch (this._mode) {
+        case 'magic': {
+          const magic1 = source.getUint32(position);
+          target.setUint32(position, magic1);
+          position += 4;
 
-            const magic2 = source.getUint32(position);
-            target.setUint32(position, magic2);
-            position += 4;
+          const magic2 = source.getUint32(position);
+          target.setUint32(position, magic2);
+          position += 4;
 
-            const magic = magic1.toString(16) + '0' + magic2.toString(16);
-            console.log('%cPNG magic:     %c %o', 'font-weight: bold', '', magic);
-            if (magic !== '89504e470d0a1a0a') {
-              throw new TypeError('This is not a PNG');
-            }
-
-            this._mode = 'header';
-            break;
+          const magic = magic1.toString(16) + '0' + magic2.toString(16);
+          console.log('%cPNG magic:     %c %o', 'font-weight: bold', '', magic);
+          if (magic !== '89504e470d0a1a0a') {
+            throw new TypeError('This is not a PNG');
           }
-          case 'header': {
-            // Read chunk info
-            const chunkLength = source.getUint32(position);
-            target.setUint32(position, chunkLength);
-            position += 4;
-            const chunkName = this._readString(source, position, 4);
-            this._writeString(target, position, chunkName);
-            position += 4;
-            if (chunkName !== 'IHDR') {
-              throw new TypeError('PNG is missing IHDR chunk');
-            }
 
-            // Read image dimensions
-            this._width = source.getUint32(position);
-            target.setUint32(position, this._width);
-            position += 4;
-            this._height = source.getUint32(position);
-            target.setUint32(position, this._height);
-            position += 4;
-            console.log('%cPNG dimensions:%c %d x %d', 'font-weight: bold', '', this._width, this._height);
-
-            const bitDepth = source.getUint8(position);
-            target.setUint8(position, bitDepth);
-            position += 1;
-            console.log('%cPNG bit depth: %c %d', 'font-weight: bold', '', bitDepth);
-
-            const colorType = source.getUint8(position);
-            target.setUint8(position, colorType);
-            position += 1;
-            console.log('%cPNG color type:%c %s', 'font-weight: bold', '', this._colorType(colorType));
-
-            const compression = source.getUint8(position);
-            target.setUint8(position, compression);
-            position += 1;
-            console.log('%cPNG compressio:%c %d', 'font-weight: bold', '', compression);
-            const filter = source.getUint8(position);
-            target.setUint8(position, filter);
-            position += 1;
-            console.log('%cPNG filter:    %c %d', 'font-weight: bold', '', filter);
-            const interlace = source.getUint8(position);
-            target.setUint8(position, interlace);
-            position += 1;
-            console.log('%cPNG interlace: %c %d', 'font-weight: bold', '', interlace);
-
-            const chunkCrc = source.getUint32(position);
-            target.setUint32(position, chunkCrc);
-            position += 4;
-
-            this._mode = 'data';
-            break;
+          this._mode = 'header';
+          break;
+        }
+        case 'header': {
+          // Read chunk info
+          const chunkLength = source.getUint32(position);
+          target.setUint32(position, chunkLength);
+          position += 4;
+          const chunkName = this.readString(source, position, 4);
+          this.writeString(target, position, chunkName);
+          position += 4;
+          if (chunkName !== 'IHDR') {
+            throw new TypeError('PNG is missing IHDR chunk');
           }
-          case 'data': {
-            // Read chunk info
-            const dataSize = source.getUint32(position);
-            console.log('%cPNG data size: %c %d', 'font-weight: bold', '', dataSize);
 
-            const chunkName = this._readString(source, position + 4, 4);
-            if (chunkName !== 'IDAT') {
-              throw new TypeError('PNG is missing IDAT chunk');
-            }
+          // Read image dimensions
+          this._width = source.getUint32(position);
+          target.setUint32(position, this._width);
+          position += 4;
+          this._height = source.getUint32(position);
+          target.setUint32(position, this._height);
+          position += 4;
+          console.log('%cPNG dimensions:%c %d x %d', 'font-weight: bold', '', this._width, this._height);
 
-            const crcStart = position + 4;
+          this._bitDepth = source.getUint8(position);
+          target.setUint8(position, this._bitDepth);
+          position += 1;
+          console.log('%cPNG bit depth: %c %d', 'font-weight: bold', '', this._bitDepth);
 
-            // Extract the data from the PNG stream
-            const bytesPerCol = 4;
-            const bytesPerRow = this._width * bytesPerCol + 1;
-            let result = value.subarray(position + 8, position + 8 + dataSize);
+          this._colorType = source.getUint8(position);
+          target.setUint8(position, this._colorType);
+          position += 1;
+          console.log('%cPNG color type:%c %s', 'font-weight: bold', '', this.colorType(this._colorType));
 
-            // Decompress the data
-            result = pako.inflate(result);
+          const compression = source.getUint8(position);
+          target.setUint8(position, compression);
+          position += 1;
+          console.log('%cPNG compressio:%c %d', 'font-weight: bold', '', compression);
+          const filter = source.getUint8(position);
+          target.setUint8(position, filter);
+          position += 1;
+          console.log('%cPNG filter:    %c %d', 'font-weight: bold', '', filter);
+          const interlace = source.getUint8(position);
+          target.setUint8(position, interlace);
+          position += 1;
+          console.log('%cPNG interlace: %c %d', 'font-weight: bold', '', interlace);
 
-            // Remove PNG filters from each scanline
-            result = this._removeFilters(result, bytesPerCol, bytesPerRow);
+          const chunkCrc = source.getUint32(position);
+          target.setUint32(position, chunkCrc);
+          position += 4;
 
-            // Actually grayscale the image
-            result = this._grayscale(result, bytesPerCol, bytesPerRow);
+          this._mode = 'data';
+          break;
+        }
+        case 'data': {
+          // Read chunk info
+          const dataSize = source.getUint32(position);
+          console.log('%cPNG data size: %c %d', 'font-weight: bold', '', dataSize);
 
-            // Compress with Deflate
-            result = pako.deflate(result);
-
-            // Write data to target
-            target.setUint32(position, result.byteLength);
-            this._writeString(target, position + 4, 'IDAT');
-            buffer.set(result, position + 8);
-
-            position += result.byteLength + 8;
-
-            const chunkCrc = crc32(chunkName, result);
-            target.setUint32(position, chunkCrc);
-            position += 4;
-
-            this._mode = 'end';
-            break;
+          const chunkName = this.readString(source, position + 4, 4);
+          if (chunkName !== 'IDAT') {
+            throw new TypeError('PNG is missing IDAT chunk');
           }
-          case 'end': {
-            // Write IEND chunk
-            target.setUint32(position, 0);
-            position += 4;
-            this._writeString(target, position, "IEND");
-            position += 4;
-            target.setUint32(position, 2923585666);
-            position += 4;
 
-            controller.enqueue(buffer.subarray(0, position));
-            controller.close();
-            return;
-          }
+          const crcStart = position + 4;
+
+          // Extract the data from the PNG stream
+          const bytesPerCol = this.bytesPerPixel();
+          const bytesPerRow = this._width * bytesPerCol + 1;
+          let result = chunk.subarray(position + 8, position + 8 + dataSize);
+
+          // Decompress the data
+          result = pako.inflate(result);
+
+          // Remove PNG filters from each scanline
+          result = this.removeFilters(result, bytesPerCol, bytesPerRow);
+
+          // Actually grayscale the image
+          result = this.grayscale(result, bytesPerCol, bytesPerRow);
+
+          // Compress with Deflate
+          result = pako.deflate(result);
+
+          // Write data to target
+          target.setUint32(position, result.byteLength);
+          this.writeString(target, position + 4, 'IDAT');
+          buffer.set(result, position + 8);
+
+          position += result.byteLength + 8;
+
+          const chunkCrc = crc32(chunkName, result);
+          target.setUint32(position, chunkCrc);
+          position += 4;
+
+          this._mode = 'end';
+          break;
+        }
+        case 'end': {
+          // Write IEND chunk
+          target.setUint32(position, 0);
+          position += 4;
+          this.writeString(target, position, 'IEND');
+          position += 4;
+          target.setUint32(position, 2923585666);
+          position += 4;
+
+          controller.enqueue(buffer.subarray(0, position));
+          return;
         }
       }
-    });
-  }
-
-  cancel(reason) {
-    return this._rs.cancel(reason);
-  }
-
-  /**
-   * @param {ReadableStreamDefaultController} controller
-   * @param {ReadableStreamDefaultReader} reader
-   * @param {Uint8Array} uint8Array
-   */
-  _pump(controller, reader, uint8Array) {
-    return reader.read().then(({ value, done }) => {
-      if (done) {
-        return uint8Array;
-      }
-
-      const newArray = new Uint8Array(uint8Array.length + value.length);
-      newArray.set(uint8Array);
-      newArray.set(value, uint8Array.length);
-      return this._pump(controller, reader, newArray);
-    }).catch((err) => console.error(err));
+    }
   }
 
   /**
@@ -201,7 +174,7 @@ class GrayscalePNGSource {
    * @param {number} position
    * @param {number} length
    */
-  _readString(dataView, position, length) {
+  readString(dataView, position, length) {
     return new Array(length)
       .fill(0)
       .map((e, index) => String.fromCharCode(dataView.getUint8(position + index))).join('');
@@ -212,7 +185,7 @@ class GrayscalePNGSource {
    * @param {number} position
    * @param {string} string
    */
-  _writeString(dataView, position, string) {
+  writeString(dataView, position, string) {
     string.split('').forEach((char, index) => dataView.setUint8(position + index, char.charCodeAt(0)));
   }
 
@@ -222,7 +195,7 @@ class GrayscalePNGSource {
    * @param {number} number A number representing the color type.
    * @return {string} A string naming the color type.
    */
-  _colorType(number) {
+  colorType(number) {
     switch (number) {
       case 0: return 'grayscale';
       case 2: return 'rgb';
@@ -232,7 +205,34 @@ class GrayscalePNGSource {
     }
   }
 
-  _removeFilters(src, bytesPerCol, bytesPerRow) {
+  /**
+   * Returns the number of bytes to read per pixel.
+   *
+   * @return {number}
+   */
+  bytesPerPixel() {
+    if (this._bitDepth < 8) {
+      throw new Error('Bit depths below 8 bit are currently not supported.');
+    }
+
+    const byteDepth = this._bitDepth / 8;
+    if (this._colorType === 0) {
+      return byteDepth;
+    }
+    if (this._colorType === 2) {
+      return 3 * byteDepth;
+    }
+    if (this._colorType === 3) {
+      return byteDepth;
+    }
+    if (this._colorType === 4) {
+      return 2 * byteDepth;
+    }
+
+    return 4 * byteDepth;
+  }
+
+  removeFilters(src, bytesPerCol, bytesPerRow) {
     const dest = src.slice();
     for (let y = 0, i = y * bytesPerRow; y < this._height; y += 1, i = y * bytesPerRow) {
       const filter = src[i];
@@ -275,7 +275,7 @@ class GrayscalePNGSource {
     return dest;
   }
 
-  _grayscale(src, bytesPerCol, bytesPerRow) {
+  grayscale(src, bytesPerCol, bytesPerRow) {
     const dest = src.slice();
     for (let y = 0, i = y * bytesPerRow; y < this._height; y += 1, i = y * bytesPerRow) {
       const filter = src[i];

--- a/streams/png-transform-stream/index.html
+++ b/streams/png-transform-stream/index.html
@@ -21,6 +21,7 @@
   <thead>
   <tr>
     <th width="300">Stream</th>
+    <th>Chunk No.</th>
     <th>Sent chunk type</th>
   </tr>
   </thead>
@@ -33,48 +34,74 @@
 <script src="png-transform-stream.js"></script>
 <script type="application/javascript">
   const tbody = document.getElementsByTagName('tbody')[0];
+
+  class LogStreamSink {
+    /**
+     * @param {string} name
+     */
+    constructor(name) {
+      this.name = name;
+      this.counter = 0;
+    }
+
+    /**
+     * Called when a chunk is written to the log.
+     */
+    write(chunk) {
+      this.counter += 1;
+      console.log('Chunk %d of %s: %o', this.counter, this.name, chunk);
+
+      this.createRow(this.name, this.counter, chunk.constructor.name);
+    }
+
+    /**
+     * Called when the stream is closed.
+     */
+    close() {
+      this.createRow(this.name, this.counter, 'Closed');
+    }
+
+    /**
+     * Creates a row in the table.
+     *
+     * @param {string} heading
+     * @param {string} col1
+     * @param {string} col2
+     */
+    createRow(heading, col1, col2) {
+      const tr = document.createElement('tr');
+      tbody.appendChild(tr);
+      const th = document.createElement('th');
+      th.appendChild(document.createTextNode(heading));
+      tr.appendChild(th);
+      const tdCounter = document.createElement('td');
+      tdCounter.appendChild(document.createTextNode(col1));
+      tr.appendChild(tdCounter);
+      const tdChunk = document.createElement('td');
+      tdChunk.appendChild(document.createTextNode(col2));
+      tr.appendChild(tdChunk);
+    }
+  }
+
   function logReadableStream(name, rs) {
     const [rs1, rs2] = rs.tee();
-    const reader = rs2.getReader();
-    let i = 0;
 
-    pump();
-
-    function pump() {
-      return reader.read().then(({ done, value }) => {
-        const tr = document.createElement('tr');
-        tbody.appendChild(tr);
-        const th = document.createElement('th');
-        th.appendChild(document.createTextNode(name));
-        tr.appendChild(th);
-        if (done) {
-          const tdClose = document.createElement('td');
-          tdClose.appendChild(document.createTextNode('Closed'))
-          tr.appendChild(tdClose);
-          console.log('Closed %s.', name);
-          return;
-        }
-        const tdChunk = document.createElement('td');
-        tdChunk.appendChild(document.createTextNode(value.constructor.name))
-        tr.appendChild(tdChunk);
-        console.log('Chunk %d of %s: %o', i += 1, name, value);
-
-        return pump();
-      })
-    }
+    rs2.pipeTo(new WritableStream(new LogStreamSink(name))).catch(console.error);
 
     return rs1;
   }
 
 
-// Fetch the original image
-fetch('png-logo.png')
-// Retrieve its body as ReadableStream
-.then(response => response.body)
-// Create a gray-scaled PNG stream out of the original
-.then(rs => logReadableStream('Fetch Response Stream', rs))
-.then(body => body.pipeThrough(new PNGTransformStream()))
-.then(rs => logReadableStream('PNG Chunk Stream', rs))
+  // Fetch the original image
+  fetch('png-logo.png')
+  // Retrieve its body as ReadableStream
+  .then(response => response.body)
+  // Log each fetched Uint8Array chunk
+  .then(rs => logReadableStream('Fetch Response Stream', rs))
+  // Transform to a PNG chunk stream
+  .then(rs => rs.pipeThrough(new PNGTransformStream()))
+  // Log each transformed PNG chunk
+  .then(rs => logReadableStream('PNG Chunk Stream', rs))
 
 </script>
 </body>

--- a/streams/png-transform-stream/png-chunks.js
+++ b/streams/png-transform-stream/png-chunks.js
@@ -142,6 +142,54 @@ class sRGBChunk extends PNGChunk {
 }
 
 /**
+ * A bKGD chunk containing the PNG's background color.
+ */
+class bKGDChunk extends PNGChunk {
+  constructor({ data }) {
+    super({ name: 'bKGD', data });
+    const dv = new DataView(data);
+    if (data.byteLength === 1) {
+      defineDataViewProperty(this, 'paletteColor', dv, 8, 0);
+    } else if (data.byteLength === 2) {
+      defineDataViewProperty(this, 'gray', dv, 16, 0);
+    } else {
+      defineDataViewProperty(this, 'red', dv, 16, 0);
+      defineDataViewProperty(this, 'green', dv, 16, 2);
+      defineDataViewProperty(this, 'blue', dv, 16, 4);
+    }
+  }
+}
+
+/**
+ * A pHYs chunk containing physical pixel dimensions.
+ */
+class pHYsChunk extends PNGChunk {
+  constructor({ data }) {
+    super({ name: 'pHYs', data });
+    const dv = new DataView(data);
+    defineDataViewProperty(this, 'pixelsPerUnitX', dv, 32, 0);
+    defineDataViewProperty(this, 'pixelsPerUnitY', dv, 32, 4);
+    defineDataViewProperty(this, 'unit', dv, 8, 8);
+  }
+}
+
+/**
+ * A tIME chunk gives the time of the last image modification.
+ */
+class tIMEChunk extends PNGChunk {
+  constructor({ data }) {
+    super({ name: 'tIME', data });
+    const dv = new DataView(data);
+    defineDataViewProperty(this, 'year', dv, 16, 0);
+    defineDataViewProperty(this, 'month', dv, 8, 2);
+    defineDataViewProperty(this, 'day', dv, 8, 3);
+    defineDataViewProperty(this, 'hour', dv, 8, 4);
+    defineDataViewProperty(this, 'minute', dv, 8, 5);
+    defineDataViewProperty(this, 'second', dv, 8, 6);
+  }
+}
+
+/**
  * Function to create a PNG chunk from its name and data.
  *
  * @param {string} name The PNG chunk's name.
@@ -160,6 +208,12 @@ function createChunk({ name, data }) {
       return new tEXtChunk({ data });
     case 'sRGB':
       return new sRGBChunk({ data });
+    case 'bKGD':
+      return new bKGDChunk({ data });
+    case 'pHYs':
+      return new pHYsChunk({ data });
+    case 'tIME':
+      return new tIMEChunk({ data });
     default:
       return new PNGChunk({ name, data });
   }

--- a/streams/simple-pump/index.html
+++ b/streams/simple-pump/index.html
@@ -17,34 +17,38 @@
   // Fetch the original image
   fetch('./tortoise.png')
   // Retrieve its body as ReadableStream
-  .then(response => {
-    const reader = response.body.getReader();
+  .then(response => response.body)
+  .then(rs => {
+    const reader = rs.getReader();
 
     return new ReadableStream({
-      start(controller) {
-        return pump();
+      async start(controller) {
+        while (true) {
+          const { done, value } = await reader.read();
 
-        function pump() {
-          return reader.read().then(({ done, value }) => {
-            // When no more data needs to be consumed, close the stream
-            if (done) {
-              controller.close();
-              return;
-            }
+          // When no more data needs to be consumed, break the reading
+          if (done) {
+            break;
+          }
 
-            // Enqueue the next data chunk into our target stream
-            controller.enqueue(value);
-            return pump();
-          });
+          // Enqueue the next data chunk into our target stream
+          controller.enqueue(value);
         }
+
+        // Close the stream
+        controller.close();
+        reader.releaseLock();
       }
     })
   })
-  .then(stream => new Response(stream))
+  // Create a new response out of the stream
+  .then(rs => new Response(rs))
+  // Create an object URL for the response
   .then(response => response.blob())
   .then(blob => URL.createObjectURL(blob))
-  .then(url => console.log(image.src = url))
-  .catch(err => console.error(err));
+  // Update image
+  .then(url => image.src = url)
+  .catch(console.error);
 </script>
 </body>
 </html>


### PR DESCRIPTION
The spec now includes TransformStreams and encourages the user to use async/await code with while-loops instead of recursive function calls. I updated my examples based on feedback I got for [a PR I filed against the spec repository to add demos](https://github.com/whatwg/streams/pull/911). The examples are tested on Chrome with the _Experimental Web Platform features_ flag (chrome://flags/#enable-experimental-web-platform-features) activated.

See PR: https://github.com/whatwg/streams/pull/911