### PR TITLE
Added server-sent-events/README.md

### DIFF
--- a/server-sent-events/README.md
+++ b/server-sent-events/README.md
@@ -1,0 +1,3 @@
+## Note about running this example through **NGINX**:
+
+By default `fastcgi_buffering` is ON, thus you have to add `fastcgi_buffering off;` to the appropriate `location` block for this example to work.


### PR DESCRIPTION
I've spent some time trying to make this example work with no luck, and in the end, I've found that `fastcgi_buffering` was causing troubles.
I think it is worth mentioning this small fact.