### PR TITLE
Improving channel messaging examples

### DIFF
--- a/channel-messaging-basic/index.html
+++ b/channel-messaging-basic/index.html
@@ -4,39 +4,35 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width">
-
     <title>Channel messaging demo</title>
-
     <link rel="stylesheet" href="">
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
   </head>
-
   <body>
     <h1>Channel messaging demo</h1>
-    <p>My body</p>
-
-    <iframe src="page2.html" width='480' height='320'>
-    </iframe>
+    <p class="output">My body</p>
+    <iframe src="page2.html" width='480' height='320'></iframe>
   </body>
   <script>
     var channel = new MessageChannel();
-    var para = document.querySelector('p');
-    
-    var ifr = document.querySelector('iframe');
-    var otherWindow = ifr.contentWindow;
+    var output = document.querySelector('.output');
+    var iframe = document.querySelector('iframe');
 
-    ifr.addEventListener("load", iframeLoaded, false);
+    // Wait for the iframe to load
+    iframe.addEventListener("load", onLoad);
     
-    function iframeLoaded() {
-      otherWindow.postMessage('Hello from the main page!', '*', [channel.port2]);
+    function onLoad() {
+      // Listen for messages on port1
+      channel.port1.onmessage = onMessage;
+      // Transfer port2 to the iframe
+      iframe.contentWindow.postMessage('Hello from the main page!', '*', [channel.port2]);
     }
 
-    channel.port1.onmessage = handleMessage;
-    function handleMessage(e) {
-      	para.innerHTML = e.data;
+    // Handle messages received on port1
+    function onMessage(e) {
+      output.innerHTML = e.data;
     }
-
   </script>
 </html>

--- a/channel-messaging-basic/page2.html
+++ b/channel-messaging-basic/page2.html
@@ -4,27 +4,24 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width">
-
     <title>My page title</title>
-
     <link rel="stylesheet" href="">
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
   </head>
-
   <body>
-    <p>iFrame body</p>
+    <p class="output">iFrame body</p>
   </body>
   <script>
-  var para = document.querySelector('p');
+  var output = document.querySelector('.output');
 
-  onmessage = function(e) {
-  	para.innerHTML = e.data;
-  	// e.ports[0] is channel.port2, sent from the main frame
+  window.addEventListener('message', onMessage);
+  
+  function onMessage(e) {
+  	output.innerHTML = e.data;
+    // Use the transfered port to post a message back to the main frame
   	e.ports[0].postMessage('Message back from the IFrame');
   }
-  
-
   </script>
 </html>

--- a/channel-messaging-multimessage/index.html
+++ b/channel-messaging-multimessage/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width">
-
     <title>Channel messaging demo</title>
     <link href='http://fonts.googleapis.com/css?family=Open+Sans+Condensed:300|Lobster+Two' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="style.css">
@@ -12,45 +11,48 @@
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
   </head>
-
   <body>
     <h1>Channel messaging demo</h1>
-    <p>Message not yet sent</p>
+    <p id="message-output">Message not yet sent</p>
 
     <form>
-      <label for="message-box">Send a message</label>
-      <input type="text" id="message-box" class="message-box" autofocus>
+      <label for="message-input">Send a message</label>
+      <input type="text" id="message-input" autofocus>
       <button>Send Message</button>
     </form>
 
-    <iframe src="page2.html" width='480' height='320'>
-    </iframe>
+    <iframe src="page2.html" width='480' height='320'></iframe>
   </body>
   <script>
-    var para = document.querySelector('p');
-
-    var textInput = document.querySelector('.message-box');
+    var input = document.getElementById('message-input');
+    var output = document.getElementById('message-output');
     var button = document.querySelector('button');
-    
-    var ifr = document.querySelector('iframe');
-    var otherWindow = ifr.contentWindow;
+    var iframe = document.querySelector('iframe');
+    var channel = new MessageChannel();
+    var port1 = channel.port1;
 
-    ifr.addEventListener("load", iframeLoaded, false);
+    // Wait for the iframe to load
+    iframe.addEventListener("load", onLoad);
     
-    function iframeLoaded() {
-      button.onclick = function(e) {
-        e.preventDefault();
-        
-        var channel = new MessageChannel();
-        otherWindow.postMessage(textInput.value, '*', [channel.port2]);
-
-        channel.port1.onmessage = handleMessage;
-        function handleMessage(e) {
-          para.innerHTML = e.data;
-          textInput.value = '';
-        } 
-      }
+    function onLoad() {
+      // Listen for button clicks
+      button.addEventListener('click', onClick);
+      // Listen for messages on port1
+      port1.onmessage = onMessage;
+      // Transfer port2 to the iframe
+      iframe.contentWindow.postMessage('init', '*', [channel.port2]);
     }
 
+    // Post a message on port1 when the button is clicked
+    function onClick(e) {
+      e.preventDefault();
+      port1.postMessage(input.value);
+    }
+
+    // Handle messages received on port1
+    function onMessage(e) {
+      output.innerHTML = e.data;
+      input.value = '';
+    }
   </script>
 </html>

--- a/channel-messaging-multimessage/page2.html
+++ b/channel-messaging-multimessage/page2.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width">
-
     <title>My page title</title>
     <link href='http://fonts.googleapis.com/css?family=Open+Sans+Condensed:300|Lobster+Two' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="style.css">
@@ -12,23 +11,28 @@
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
   </head>
-
   <body>
-    <ul>
-      
-    </ul>
+    <ul></ul>
   </body>
   <script>
-  var list = document.querySelector('ul');
+    var list = document.querySelector('ul');
+    var port2;
+    
+    // Listen for the intial port transfer message
+    window.addEventListener('message', initPort);
 
-  onmessage = function(e) {
-    var listItem = document.createElement('li');
-    listItem.textContent = e.data;
-  	list.appendChild(listItem);
-  	// e.ports[0] is channel.port2, sent from the main frame
-  	e.ports[0].postMessage('Message received by IFrame: "' + e.data + '"');
-  }
-  
+    // Setup the transfered port
+    function initPort(e) {
+      port2 = e.ports[0];
+      port2.onmessage = onMessage;
+    }
 
+    // Handle messages received on port2
+    function onMessage(e) {
+      var listItem = document.createElement('li');
+      listItem.textContent = e.data;
+      list.appendChild(listItem);
+      port2.postMessage('Message received by IFrame: "' + e.data + '"');
+    }
   </script>
 </html>


### PR DESCRIPTION
This addresses #25.

- The `channel-messaging-basic` has been cleaned up a bit
- The `channel-messaging-multimessage` does no longer create a new `MessageChannel` every time. Instead a single `MessageChannel` is created, and one of its ports is initially transfered to the iframe using `iframe.contentWindow.postMessage`. All succeeding messages sent between the main frame and the iframe are sent using the ports.

I would be happy to update the text as well, assuming I got this right. 