### PR TITLE
Add sign/verify examples for Web Crypto

### DIFF
--- a/web-crypto/README.md
+++ b/web-crypto/README.md
@@ -1,0 +1,5 @@
+## Web Crypto API examples
+
+Examples of how to use the [Web Crypto API](https://developer.mozilla.org/docs/Web/API/Web_Crypto_API).
+
+* [sign/verify](sign-verify/index.html): examples showing how to use the [`SubtleCrypto.sign()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign) and [`SubtleCrypto.verify()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify) APIs.

--- a/web-crypto/sign-verify/ecdsa.js
+++ b/web-crypto/sign-verify/ecdsa.js
@@ -58,11 +58,7 @@
       encoded
     );
 
-    if (result) {
-      signatureValue.classList.add("valid");
-    } else {
-      signatureValue.classList.add("invalid");
-    }
+    signatureValue.classList.add(result ? "valid" : "invalid");
   }
 
   /*

--- a/web-crypto/sign-verify/ecdsa.js
+++ b/web-crypto/sign-verify/ecdsa.js
@@ -1,4 +1,4 @@
-(function() {
+(() => {
 
   /*
   Store the calculated signature here, so we can verify it later.

--- a/web-crypto/sign-verify/ecdsa.js
+++ b/web-crypto/sign-verify/ecdsa.js
@@ -34,6 +34,10 @@
       encoded
     );
 
+    signatureValue.classList.add('fade-in');
+    signatureValue.addEventListener('animationend', () => {
+      signatureValue.classList.remove('fade-in');
+    });
     let buffer = new Uint8Array(signature, 0, 10);
     signatureValue.textContent = buffer;
   }

--- a/web-crypto/sign-verify/ecdsa.js
+++ b/web-crypto/sign-verify/ecdsa.js
@@ -1,0 +1,93 @@
+(function() {
+
+  /*
+  Store the calculated signature here, so we can verify it later.
+  */
+  let signature;
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for sign operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".ecdsa #message");
+    let message = messageBox.value;
+    let enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message-to-sign, sign it and display a representation
+  of the first part of it in the "signature" element.
+  */
+  async function signMessage(privateKey) {
+    const signatureValue = document.querySelector(".ecdsa .signature-value");
+    signatureValue.classList.remove("valid");
+    signatureValue.classList.remove("invalid");
+
+    let encoded = getMessageEncoding();
+    signature = await window.crypto.subtle.sign(
+      {
+        name: "ECDSA",
+        hash: {name: "SHA-384"},
+      },
+      privateKey,
+      encoded
+    );
+
+    let buffer = new Uint8Array(signature, 0, 10);
+    signatureValue.textContent = buffer;
+  }
+
+  /*
+  Fetch the encoded message-to-sign and verify it against the stored signature.
+  * If it checks out, set the "valid" class on the signature.
+  * Otherwise set the "invalid" class.
+  */
+  async function verifyMessage(publicKey) {
+    const signatureValue = document.querySelector(".ecdsa .signature-value");
+    signatureValue.classList.remove("valid");
+    signatureValue.classList.remove("invalid");
+
+    let encoded = getMessageEncoding();
+    let result = await window.crypto.subtle.verify(
+      {
+        name: "ECDSA",
+        hash: {name: "SHA-384"},
+      },
+      publicKey,
+      signature,
+      encoded
+    );
+
+    if (result) {
+      signatureValue.classList.add("valid");
+    } else {
+      signatureValue.classList.add("invalid");
+    }
+  }
+
+  /*
+  Generate a sign/verify key, then set up event listeners
+  on the "Sign" and "Verify" buttons.
+  */
+  window.crypto.subtle.generateKey(
+    {
+      name: "ECDSA",
+      namedCurve: "P-384"
+    },
+    true,
+    ["sign", "verify"]
+  ).then((keyPair) => {
+    const signButton = document.querySelector(".ecdsa .sign-button");
+    signButton.addEventListener("click", () => {
+      signMessage(keyPair.privateKey);
+    });
+
+    const verifyButton = document.querySelector(".ecdsa .verify-button");
+    verifyButton.addEventListener("click", () => {
+      verifyMessage(keyPair.publicKey);
+    });
+  });
+
+})();

--- a/web-crypto/sign-verify/ecdsa.js
+++ b/web-crypto/sign-verify/ecdsa.js
@@ -22,8 +22,7 @@
   */
   async function signMessage(privateKey) {
     const signatureValue = document.querySelector(".ecdsa .signature-value");
-    signatureValue.classList.remove("valid");
-    signatureValue.classList.remove("invalid");
+    signatureValue.classList.remove("valid", "invalid");
 
     let encoded = getMessageEncoding();
     signature = await window.crypto.subtle.sign(
@@ -46,8 +45,7 @@
   */
   async function verifyMessage(publicKey) {
     const signatureValue = document.querySelector(".ecdsa .signature-value");
-    signatureValue.classList.remove("valid");
-    signatureValue.classList.remove("invalid");
+    signatureValue.classList.remove("valid", "invalid");
 
     let encoded = getMessageEncoding();
     let result = await window.crypto.subtle.verify(

--- a/web-crypto/sign-verify/hmac.js
+++ b/web-crypto/sign-verify/hmac.js
@@ -1,4 +1,4 @@
-(function() {
+(() => {
 
   /*
   Store the calculated signature here, so we can verify it later.

--- a/web-crypto/sign-verify/hmac.js
+++ b/web-crypto/sign-verify/hmac.js
@@ -31,6 +31,10 @@
       encoded
     );
 
+    signatureValue.classList.add('fade-in');
+    signatureValue.addEventListener('animationend', () => {
+      signatureValue.classList.remove('fade-in');
+    });
     let buffer = new Uint8Array(signature, 0, 10);
     signatureValue.textContent = buffer;
   }

--- a/web-crypto/sign-verify/hmac.js
+++ b/web-crypto/sign-verify/hmac.js
@@ -52,11 +52,7 @@
       encoded
     );
 
-    if (result) {
-      signatureValue.classList.add("valid");
-    } else {
-      signatureValue.classList.add("invalid");
-    }
+    signatureValue.classList.add(result ? "valid" : "invalid");
   }
 
   /*

--- a/web-crypto/sign-verify/hmac.js
+++ b/web-crypto/sign-verify/hmac.js
@@ -1,0 +1,87 @@
+(function() {
+
+  /*
+  Store the calculated signature here, so we can verify it later.
+  */
+  let signature;
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for sign operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".hmac #message");
+    let message = messageBox.value;
+    let enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message-to-sign, sign it and display a representation
+  of the first part of it in the "signature" element.
+  */
+  async function signMessage(key) {
+    const signatureValue = document.querySelector(".hmac .signature-value");
+    signatureValue.classList.remove("valid");
+    signatureValue.classList.remove("invalid");
+
+    let encoded = getMessageEncoding();
+    signature = await window.crypto.subtle.sign(
+      "HMAC",
+      key,
+      encoded
+    );
+
+    let buffer = new Uint8Array(signature, 0, 10);
+    signatureValue.textContent = buffer;
+  }
+
+  /*
+  Fetch the encoded message-to-sign and verify it against the stored signature.
+  * If it checks out, set the "valid" class on the signature.
+  * Otherwise set the "invalid" class.
+  */
+  async function verifyMessage(key) {
+    const signatureValue = document.querySelector(".hmac .signature-value");
+    signatureValue.classList.remove("valid");
+    signatureValue.classList.remove("invalid");
+
+    let encoded = getMessageEncoding();
+    let result = await window.crypto.subtle.verify(
+      "HMAC",
+      key,
+      signature,
+      encoded
+    );
+
+    if (result) {
+      signatureValue.classList.add("valid");
+    } else {
+      signatureValue.classList.add("invalid");
+    }
+  }
+
+  /*
+  Generate a sign/verify key, then set up event listeners
+  on the "Sign" and "Verify" buttons.
+  */
+  window.crypto.subtle.generateKey(
+    {
+      name: "HMAC",
+      hash: {name: "SHA-384"}
+    },
+    true,
+    ["sign", "verify"]
+  ).then((key) => {
+    const signButton = document.querySelector(".hmac .sign-button");
+    signButton.addEventListener("click", () => {
+      signMessage(key);
+    });
+
+    const verifyButton = document.querySelector(".hmac .verify-button");
+    verifyButton.addEventListener("click", () => {
+      verifyMessage(key);
+    });
+  });
+
+})();

--- a/web-crypto/sign-verify/hmac.js
+++ b/web-crypto/sign-verify/hmac.js
@@ -62,7 +62,7 @@
   window.crypto.subtle.generateKey(
     {
       name: "HMAC",
-      hash: {name: "SHA-384"}
+      hash: {name: "SHA-512"}
     },
     true,
     ["sign", "verify"]

--- a/web-crypto/sign-verify/hmac.js
+++ b/web-crypto/sign-verify/hmac.js
@@ -22,8 +22,7 @@
   */
   async function signMessage(key) {
     const signatureValue = document.querySelector(".hmac .signature-value");
-    signatureValue.classList.remove("valid");
-    signatureValue.classList.remove("invalid");
+    signatureValue.classList.remove("valid", "invalid");
 
     let encoded = getMessageEncoding();
     signature = await window.crypto.subtle.sign(
@@ -43,8 +42,7 @@
   */
   async function verifyMessage(key) {
     const signatureValue = document.querySelector(".hmac .signature-value");
-    signatureValue.classList.remove("valid");
-    signatureValue.classList.remove("invalid");
+    signatureValue.classList.remove("valid", "invalid");
 
     let encoded = getMessageEncoding();
     let result = await window.crypto.subtle.verify(

--- a/web-crypto/sign-verify/index.html
+++ b/web-crypto/sign-verify/index.html
@@ -11,6 +11,14 @@
       <h1>Web Crypto: sign/verify</h1>
 
       <section class="description">
+        <p>This page shows the use of the <code>sign()</code> and <code>verify()</code> functions of the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API">Web Crypto API</a>. It contains four separate examples, one for each signing algorithm supported:</p>
+        <ul>
+          <li>"RSASSA-PKCS1-v1_5"</li>
+          <li>"RSA-PSS"</li>
+          <li>"ECDSA"</li>
+          <li>"HMAC"</li>
+        </ul>
+        <hr/>
         <p>Each example has four components:</p>
         <ul>
           <li>A text box containing a message to sign.</li>

--- a/web-crypto/sign-verify/index.html
+++ b/web-crypto/sign-verify/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Web Crypto API example</title>
+    <link rel="stylesheet" href="style.css">
+  </head>
+
+  <body>
+    <main>
+      <h1>Web Crypto: sign/verify</h1>
+
+      <section class="description">
+        <p>Each example has four components:</p>
+        <ul>
+          <li>A text box containing a message to sign.</li>
+          <li>A representation of the signature.</li>
+          <li>A "Sign" button: this signs the text box contents, displays part of the signature, and stores the complete signature.</li>
+          <li>A "Verify" button: this verifies the text box contents against the stored signature, and styles the displayed signature according to the result.</li>
+        </ul>
+        <p>Try it:</p>
+        <ul>
+          <li>Press "Sign". The signature should appear.</li>
+          <li>Press "Verify". The signature should be styled as valid.</li>
+          <li>Edit the text box contents.</li>
+          <li>Press "Verify". The signature should be styled as invalid.</li>
+        </ul>
+      </section>
+
+      <section class="examples">
+        <section class="sign-verify rsassa-pkcs1">
+          <h2 class="sign-verify-heading">RSASSA-PKCS1-v1_5</h2>
+          <section class="sign-verify-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to sign:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The owl hoots at midnight">
+            </div>
+            <div class="signature">Signature:<span class="signature-value"></span></div>
+            <input class="sign-button" type="button" value="Sign">
+            <input class="verify-button" type="button" value="Verify">
+          </section>
+        </section>
+
+        <section class="sign-verify rsa-pss">
+          <h2 class="sign-verify-heading">RSA-PSS</h2>
+          <section class="sign-verify-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to sign:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The tiger prowls at dawn">
+            </div>
+            <div class="signature">Signature:<span class="signature-value"></span></div>
+            <input class="sign-button" type="button" value="Sign">
+            <input class="verify-button" type="button" value="Verify">
+          </section>
+        </section>
+
+        <section class="sign-verify ecdsa">
+          <h2 class="sign-verify-heading">ECDSA</h2>
+          <section class="sign-verify-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to sign:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The eagle flies at twilight">
+            </div>
+            <div class="signature">Signature:<span class="signature-value"></span></div>
+            <input class="sign-button" type="button" value="Sign">
+            <input class="verify-button" type="button" value="Verify">
+          </section>
+        </section>
+
+        <section class="sign-verify hmac">
+          <h2 class="sign-verify-heading">HMAC</h2>
+          <section class="sign-verify-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to sign:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The bunny hops at teatime">
+            </div>
+            <div class="signature">Signature:<span class="signature-value"></span></div>
+            <input class="sign-button" type="button" value="Sign">
+            <input class="verify-button" type="button" value="Verify">
+          </section>
+        </section>
+      </section>
+    </main>
+
+  </body>
+  <script src="rsassa-pkcs1.js"></script>
+  <script src="rsa-pss.js"></script>
+  <script src="ecdsa.js"></script>
+  <script src="hmac.js"></script>
+</html>

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -58,11 +58,7 @@
       encoded
     );
 
-    if (result) {
-      signatureValue.classList.add("valid");
-    } else {
-      signatureValue.classList.add("invalid");
-    }
+    signatureValue.classList.add(result ? "valid" : "invalid");
   }
 
   /*

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -68,6 +68,7 @@
   window.crypto.subtle.generateKey(
     {
       name: "RSA-PSS",
+      // Consider using a 4096-bit key for systems that require long-term security
       modulusLength: 2048,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: "SHA-256",

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -68,7 +68,7 @@
   window.crypto.subtle.generateKey(
     {
       name: "RSA-PSS",
-      modulusLength: 2048,
+      modulusLength: 4096,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: "SHA-256",
     },

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -1,4 +1,4 @@
-(function() {
+(() => {
 
   /*
   Store the calculated signature here, so we can verify it later.

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -1,0 +1,95 @@
+(function() {
+
+  /*
+  Store the calculated signature here, so we can verify it later.
+  */
+  let signature;
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for sign operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".rsa-pss #message");
+    let message = messageBox.value;
+    let enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message-to-sign, sign it and display a representation
+  of the first part of it in the "signature" element.
+  */
+  async function signMessage(privateKey) {
+    const signatureValue = document.querySelector(".rsa-pss .signature-value");
+    signatureValue.classList.remove("valid");
+    signatureValue.classList.remove("invalid");
+
+    let encoded = getMessageEncoding();
+    signature = await window.crypto.subtle.sign(
+      {
+        name: "RSA-PSS",
+        saltLength: 128,
+      },
+      privateKey,
+      encoded
+    );
+
+    let buffer = new Uint8Array(signature, 0, 10);
+    signatureValue.textContent = buffer;
+  }
+
+  /*
+  Fetch the encoded message-to-sign and verify it against the stored signature.
+  * If it checks out, set the "valid" class on the signature.
+  * Otherwise set the "invalid" class.
+  */
+  async function verifyMessage(publicKey) {
+    const signatureValue = document.querySelector(".rsa-pss .signature-value");
+    signatureValue.classList.remove("valid");
+    signatureValue.classList.remove("invalid");
+
+    let encoded = getMessageEncoding();
+    let result = await window.crypto.subtle.verify(
+      {
+        name: "RSA-PSS",
+        saltLength: 128,
+      },
+      publicKey,
+      signature,
+      encoded
+    );
+
+    if (result) {
+      signatureValue.classList.add("valid");
+    } else {
+      signatureValue.classList.add("invalid");
+    }
+  }
+
+  /*
+  Generate a sign/verify key, then set up event listeners
+  on the "Sign" and "Verify" buttons.
+  */
+  window.crypto.subtle.generateKey(
+    {
+      name: "RSA-PSS",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  ).then((keyPair) => {
+    const signButton = document.querySelector(".rsa-pss .sign-button");
+    signButton.addEventListener("click", () => {
+      signMessage(keyPair.privateKey);
+    });
+
+    const verifyButton = document.querySelector(".rsa-pss .verify-button");
+    verifyButton.addEventListener("click", () => {
+      verifyMessage(keyPair.publicKey);
+    });
+  });
+
+})();

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -34,6 +34,10 @@
       encoded
     );
 
+    signatureValue.classList.add('fade-in');
+    signatureValue.addEventListener('animationend', () => {
+      signatureValue.classList.remove('fade-in');
+    });
     let buffer = new Uint8Array(signature, 0, 10);
     signatureValue.textContent = buffer;
   }

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -22,8 +22,7 @@
   */
   async function signMessage(privateKey) {
     const signatureValue = document.querySelector(".rsa-pss .signature-value");
-    signatureValue.classList.remove("valid");
-    signatureValue.classList.remove("invalid");
+    signatureValue.classList.remove("valid", "invalid");
 
     let encoded = getMessageEncoding();
     signature = await window.crypto.subtle.sign(
@@ -46,8 +45,7 @@
   */
   async function verifyMessage(publicKey) {
     const signatureValue = document.querySelector(".rsa-pss .signature-value");
-    signatureValue.classList.remove("valid");
-    signatureValue.classList.remove("invalid");
+    signatureValue.classList.remove("valid", "invalid");
 
     let encoded = getMessageEncoding();
     let result = await window.crypto.subtle.verify(

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -29,7 +29,7 @@
     signature = await window.crypto.subtle.sign(
       {
         name: "RSA-PSS",
-        saltLength: 128,
+        saltLength: 32,
       },
       privateKey,
       encoded
@@ -53,7 +53,7 @@
     let result = await window.crypto.subtle.verify(
       {
         name: "RSA-PSS",
-        saltLength: 128,
+        saltLength: 32,
       },
       publicKey,
       signature,

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -68,7 +68,7 @@
   window.crypto.subtle.generateKey(
     {
       name: "RSA-PSS",
-      modulusLength: 4096,
+      modulusLength: 2048,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: "SHA-256",
     },

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -1,0 +1,89 @@
+(function() {
+
+  /*
+  Store the calculated signature here, so we can verify it later.
+  */
+  let signature;
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for sign operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".rsassa-pkcs1 #message");
+    let message = messageBox.value;
+    let enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message-to-sign, sign it and display a representation
+  of the first part of it in the "signature" element.
+  */
+  async function signMessage(privateKey) {
+    const signatureValue = document.querySelector(".rsassa-pkcs1 .signature-value");
+    signatureValue.classList.remove("valid");
+    signatureValue.classList.remove("invalid");
+
+    let encoded = getMessageEncoding();
+    signature = await window.crypto.subtle.sign(
+      "RSASSA-PKCS1-v1_5",
+      privateKey,
+      encoded
+    );
+
+    let buffer = new Uint8Array(signature, 0, 10);
+    signatureValue.textContent = buffer;
+  }
+
+  /*
+  Fetch the encoded message-to-sign and verify it against the stored signature.
+  * If it checks out, set the "valid" class on the signature.
+  * Otherwise set the "invalid" class.
+  */
+  async function verifyMessage(publicKey) {
+    const signatureValue = document.querySelector(".rsassa-pkcs1 .signature-value");
+    signatureValue.classList.remove("valid");
+    signatureValue.classList.remove("invalid");
+
+    let encoded = getMessageEncoding();
+    let result = await window.crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      publicKey,
+      signature,
+      encoded
+    );
+
+    if (result) {
+      signatureValue.classList.add("valid");
+    } else {
+      signatureValue.classList.add("invalid");
+    }
+  }
+
+  /*
+  Generate a sign/verify key, then set up event listeners
+  on the "Sign" and "Verify" buttons.
+  */
+  generateSignVerifyKey = window.crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  ).then((keyPair) => {
+    const signButton = document.querySelector(".rsassa-pkcs1 .sign-button");
+    signButton.addEventListener("click", () => {
+      signMessage(keyPair.privateKey);
+    });
+
+    const verifyButton = document.querySelector(".rsassa-pkcs1 .verify-button");
+    verifyButton.addEventListener("click", () => {
+      verifyMessage(keyPair.publicKey);
+    });
+  });
+
+})();

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -1,4 +1,4 @@
-(function() {
+(() => {
 
   /*
   Store the calculated signature here, so we can verify it later.

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -31,6 +31,10 @@
       encoded
     );
 
+    signatureValue.classList.add('fade-in');
+    signatureValue.addEventListener('animationend', () => {
+      signatureValue.classList.remove('fade-in');
+    });
     let buffer = new Uint8Array(signature, 0, 10);
     signatureValue.textContent = buffer;
   }

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -59,7 +59,7 @@
   Generate a sign/verify key, then set up event listeners
   on the "Sign" and "Verify" buttons.
   */
-  generateSignVerifyKey = window.crypto.subtle.generateKey(
+  window.crypto.subtle.generateKey(
     {
       name: "RSASSA-PKCS1-v1_5",
       modulusLength: 4096,

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -52,11 +52,7 @@
       encoded
     );
 
-    if (result) {
-      signatureValue.classList.add("valid");
-    } else {
-      signatureValue.classList.add("invalid");
-    }
+    signatureValue.classList.add(result ? "valid" : "invalid");
   }
 
   /*

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -22,8 +22,7 @@
   */
   async function signMessage(privateKey) {
     const signatureValue = document.querySelector(".rsassa-pkcs1 .signature-value");
-    signatureValue.classList.remove("valid");
-    signatureValue.classList.remove("invalid");
+    signatureValue.classList.remove("valid", "invalid");
 
     let encoded = getMessageEncoding();
     signature = await window.crypto.subtle.sign(
@@ -43,8 +42,7 @@
   */
   async function verifyMessage(publicKey) {
     const signatureValue = document.querySelector(".rsassa-pkcs1 .signature-value");
-    signatureValue.classList.remove("valid");
-    signatureValue.classList.remove("invalid");
+    signatureValue.classList.remove("valid", "invalid");
 
     let encoded = getMessageEncoding();
     let result = await window.crypto.subtle.verify(

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -62,6 +62,7 @@
   window.crypto.subtle.generateKey(
     {
       name: "RSASSA-PKCS1-v1_5",
+      // Consider using a 4096-bit key for systems that require long-term security
       modulusLength: 2048,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: "SHA-256",

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -62,7 +62,7 @@
   window.crypto.subtle.generateKey(
     {
       name: "RSASSA-PKCS1-v1_5",
-      modulusLength: 4096,
+      modulusLength: 2048,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: "SHA-256",
     },

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -62,7 +62,7 @@
   generateSignVerifyKey = window.crypto.subtle.generateKey(
     {
       name: "RSASSA-PKCS1-v1_5",
-      modulusLength: 2048,
+      modulusLength: 4096,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: "SHA-256",
     },

--- a/web-crypto/sign-verify/style.css
+++ b/web-crypto/sign-verify/style.css
@@ -1,0 +1,110 @@
+/* General setup */
+
+* {
+	box-sizing: border-box;
+}
+
+html,body {
+	font-family: sans-serif;
+	line-height: 1.2rem;
+}
+
+/* Layout and styles */
+
+h1 {
+	color: green;
+	margin-left: .5rem;
+}
+
+.description, .sign-verify {
+	margin: 0 .5rem;
+}
+
+.description > p {
+	margin-top: 0;
+}
+
+.sign-verify {
+	box-shadow: -1px 2px 5px gray;
+	padding: .2rem .5rem;
+	margin-bottom: 2rem;
+}
+
+.sign-verify-controls > * {
+	margin: .5rem 0;
+}
+
+input[type="button"] {
+	width: 5rem;
+}
+
+.signature-value {
+	padding-left: .5rem;
+	font-size: .8rem;
+}
+
+/* Validity CSS */
+.valid {
+	color: green;
+}
+
+.invalid {
+	color: red;
+}
+
+.invalid::after {
+	 content: ' ✖';
+}
+
+.valid::after {
+  content: ' ✓';
+}
+
+/* Whole page grid */
+main {
+	display: grid;
+	grid-template-columns: 32rem 1fr;
+	grid-template-rows: 4rem 1fr;
+}
+
+h1 {
+	grid-column: 1/2;
+	grid-row: 1;
+}
+
+.examples {
+	grid-column: 1;
+	grid-row: 2;
+}
+
+.description {
+	grid-column: 2;
+	grid-row: 2;
+}
+
+/* sign-verify controls grid */
+.sign-verify-controls {
+	display: grid;
+	grid-template-columns: 1fr 5rem;
+	grid-template-rows: 1fr 1fr;
+}
+
+.message-control {
+	grid-column-start: 1;
+  grid-row-start: 1;
+}
+
+.signature {
+	grid-column-start: 1;
+  grid-row-start: 2;
+}
+
+.sign-button {
+	grid-column-start: 2;
+  grid-row-start: 1;
+}
+
+.verify-button {
+	grid-column-start: 2;
+  grid-row-start: 2;
+}

--- a/web-crypto/sign-verify/style.css
+++ b/web-crypto/sign-verify/style.css
@@ -1,110 +1,110 @@
 /* General setup */
 
 * {
-	box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 html,body {
-	font-family: sans-serif;
-	line-height: 1.2rem;
+    font-family: sans-serif;
+    line-height: 1.2rem;
 }
 
 /* Layout and styles */
 
 h1 {
-	color: green;
-	margin-left: .5rem;
+    color: green;
+    margin-left: .5rem;
 }
 
 .description, .sign-verify {
-	margin: 0 .5rem;
+    margin: 0 .5rem;
 }
 
 .description > p {
-	margin-top: 0;
+    margin-top: 0;
 }
 
 .sign-verify {
-	box-shadow: -1px 2px 5px gray;
-	padding: .2rem .5rem;
-	margin-bottom: 2rem;
+    box-shadow: -1px 2px 5px gray;
+    padding: .2rem .5rem;
+    margin-bottom: 2rem;
 }
 
 .sign-verify-controls > * {
-	margin: .5rem 0;
+    margin: .5rem 0;
 }
 
 input[type="button"] {
-	width: 5rem;
+    width: 5rem;
 }
 
 .signature-value {
-	padding-left: .5rem;
-	font-size: .8rem;
+    padding-left: .5rem;
+    font-size: .8rem;
 }
 
 /* Validity CSS */
 .valid {
-	color: green;
+    color: green;
 }
 
 .invalid {
-	color: red;
+    color: red;
 }
 
 .invalid::after {
-	 content: ' ✖';
+    content: ' ✖';
 }
 
 .valid::after {
-  content: ' ✓';
+    content: ' ✓';
 }
 
 /* Whole page grid */
 main {
-	display: grid;
-	grid-template-columns: 32rem 1fr;
-	grid-template-rows: 4rem 1fr;
+    display: grid;
+    grid-template-columns: 32rem 1fr;
+    grid-template-rows: 4rem 1fr;
 }
 
 h1 {
-	grid-column: 1/2;
-	grid-row: 1;
+    grid-column: 1/2;
+    grid-row: 1;
 }
 
 .examples {
-	grid-column: 1;
-	grid-row: 2;
+    grid-column: 1;
+    grid-row: 2;
 }
 
 .description {
-	grid-column: 2;
-	grid-row: 2;
+    grid-column: 2;
+    grid-row: 2;
 }
 
 /* sign-verify controls grid */
 .sign-verify-controls {
-	display: grid;
-	grid-template-columns: 1fr 5rem;
-	grid-template-rows: 1fr 1fr;
+    display: grid;
+    grid-template-columns: 1fr 5rem;
+    grid-template-rows: 1fr 1fr;
 }
 
 .message-control {
-	grid-column-start: 1;
-  grid-row-start: 1;
+    grid-column-start: 1;
+    grid-row-start: 1;
 }
 
 .signature {
-	grid-column-start: 1;
-  grid-row-start: 2;
+    grid-column-start: 1;
+    grid-row-start: 2;
 }
 
 .sign-button {
-	grid-column-start: 2;
-  grid-row-start: 1;
+    grid-column-start: 2;
+    grid-row-start: 1;
 }
 
 .verify-button {
-	grid-column-start: 2;
-  grid-row-start: 2;
+    grid-column-start: 2;
+    grid-row-start: 2;
 }

--- a/web-crypto/sign-verify/style.css
+++ b/web-crypto/sign-verify/style.css
@@ -108,3 +108,17 @@ h1 {
     grid-column-start: 2;
     grid-row-start: 2;
 }
+
+/* Animate output display */
+.fade-in {
+    animation: fadein .5s;
+}
+
+@keyframes fadein {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
This PR adds some examples for the [`sign()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign) and [`verify()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign) methods of the Web Crypto API.

There are 4 examples, one for each supported algorithm. This will also cover part of the [`generateKey()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign) method, because we're generating the key pairs to use for the 4 algorithms included.

I've structured it to keep the implementations for each algorithm as self-contained as possible, so they can be understood in isolation.

We should get a review from the security team before merging, but it would be good to get some feedback at this point anyway, as I'm intending to use this template for the other crypto methods, like [`encrypt()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt)/[`decrypt()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/decrypt) and [`digest()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest).