### PR TITLE
Add examples for encrypt/decrypt

### DIFF
--- a/web-crypto/README.md
+++ b/web-crypto/README.md
@@ -3,3 +3,5 @@
 Examples of how to use the [Web Crypto API](https://developer.mozilla.org/docs/Web/API/Web_Crypto_API).
 
 * [sign/verify](sign-verify/index.html): examples showing how to use the [`SubtleCrypto.sign()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign) and [`SubtleCrypto.verify()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify) APIs.
+
+* [encrypt/decrypt](encrypt-decrypt/index.html): examples showing how to use the [`SubtleCrypto.encrypt()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/encrypt) and [`SubtleCrypto.decrypt()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/decrypt) APIs.

--- a/web-crypto/encrypt-decrypt/aes-cbc.js
+++ b/web-crypto/encrypt-decrypt/aes-cbc.js
@@ -23,6 +23,7 @@
   */
   async function encryptMessage(key) {
     let encoded = getMessageEncoding();
+    // The iv must never be reused with a given key.
     iv = window.crypto.getRandomValues(new Uint8Array(16));
     ciphertext = await window.crypto.subtle.encrypt(
       {

--- a/web-crypto/encrypt-decrypt/aes-cbc.js
+++ b/web-crypto/encrypt-decrypt/aes-cbc.js
@@ -33,13 +33,13 @@
       encoded
     );
 
-    let buffer = new Uint8Array(ciphertext, 0, 10);
+    let buffer = new Uint8Array(ciphertext, 0, 5);
     const ciphertextValue = document.querySelector(".aes-cbc .ciphertext-value");
     ciphertextValue.classList.add('fade-in');
     ciphertextValue.addEventListener('animationend', () => {
       ciphertextValue.classList.remove('fade-in');
     });
-    ciphertextValue.textContent = buffer;
+    ciphertextValue.textContent = `${buffer}...[${ciphertext.byteLength} bytes total]`;
   }
 
   /*

--- a/web-crypto/encrypt-decrypt/aes-cbc.js
+++ b/web-crypto/encrypt-decrypt/aes-cbc.js
@@ -1,0 +1,93 @@
+(() => {
+
+  /*
+  Store the calculated signature here, so we can verify it later.
+  */
+  let ciphertext;
+  let iv;
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for encrypt operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".aes-cbc #message");
+    let message = messageBox.value;
+    let enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message-to-sign, sign it and display a representation
+  of the first part of it in the "signature" element.
+  */
+  async function encryptMessage(key) {
+    let encoded = getMessageEncoding();
+    iv = window.crypto.getRandomValues(new Uint8Array(16));
+    ciphertext = await window.crypto.subtle.encrypt(
+      {
+        name: "AES-CBC",
+        iv
+      },
+      key,
+      encoded
+    );
+
+    let buffer = new Uint8Array(ciphertext, 0, 10);
+    const ciphertextValue = document.querySelector(".aes-cbc .ciphertext-value");
+    ciphertextValue.classList.add('fade-in');
+    ciphertextValue.addEventListener('animationend', () => {
+      ciphertextValue.classList.remove('fade-in');
+    });
+    ciphertextValue.textContent = buffer;
+  }
+
+  /*
+  Fetch the encoded message-to-sign and verify it against the stored signature.
+  * If it checks out, set the "valid" class on the signature.
+  * Otherwise set the "invalid" class.
+  */
+  async function decryptMessage(key) {
+    let encoded = getMessageEncoding();
+    let decrypted = await window.crypto.subtle.decrypt(
+      {
+        name: "AES-CBC",
+        iv
+      },
+      key,
+      ciphertext
+    );
+
+    let dec = new TextDecoder();
+    const decryptedValue = document.querySelector(".aes-cbc .decrypted-value");
+    decryptedValue.classList.add('fade-in');
+    decryptedValue.addEventListener('animationend', () => {
+      decryptedValue.classList.remove('fade-in');
+    });
+    decryptedValue.textContent = dec.decode(decrypted);
+  }
+
+  /*
+  Generate a sign/verify key, then set up event listeners
+  on the "Sign" and "Verify" buttons.
+  */
+  window.crypto.subtle.generateKey(
+    {
+        name: "AES-CBC",
+        length: 256
+    },
+    true,
+    ["encrypt", "decrypt"]
+  ).then((key) => {
+    const encryptButton = document.querySelector(".aes-cbc .encrypt-button");
+    encryptButton.addEventListener("click", () => {
+      encryptMessage(key);
+    });
+
+    const decryptButton = document.querySelector(".aes-cbc .decrypt-button");
+    decryptButton.addEventListener("click", () => {
+      decryptMessage(key);
+    });
+  });
+
+})();

--- a/web-crypto/encrypt-decrypt/aes-cbc.js
+++ b/web-crypto/encrypt-decrypt/aes-cbc.js
@@ -11,7 +11,7 @@
   in a form we can use for the encrypt operation.
   */
   function getMessageEncoding() {
-    const messageBox = document.querySelector(".aes-cbc #message");
+    const messageBox = document.querySelector("#aes-cbc-message");
     let message = messageBox.value;
     let enc = new TextEncoder();
     return enc.encode(message);

--- a/web-crypto/encrypt-decrypt/aes-cbc.js
+++ b/web-crypto/encrypt-decrypt/aes-cbc.js
@@ -1,14 +1,14 @@
 (() => {
 
   /*
-  Store the calculated signature here, so we can verify it later.
+  Store the calculated ciphertext and IV here, so we can decrypt it later.
   */
   let ciphertext;
   let iv;
 
   /*
   Fetch the contents of the "message" textbox, and encode it
-  in a form we can use for encrypt operation.
+  in a form we can use for the encrypt operation.
   */
   function getMessageEncoding() {
     const messageBox = document.querySelector(".aes-cbc #message");
@@ -18,8 +18,8 @@
   }
 
   /*
-  Get the encoded message-to-sign, sign it and display a representation
-  of the first part of it in the "signature" element.
+  Get the encoded message, encrypt it and display a representation
+  of the ciphertext in the "Ciphertext" element.
   */
   async function encryptMessage(key) {
     let encoded = getMessageEncoding();
@@ -43,9 +43,8 @@
   }
 
   /*
-  Fetch the encoded message-to-sign and verify it against the stored signature.
-  * If it checks out, set the "valid" class on the signature.
-  * Otherwise set the "invalid" class.
+  Fetch the encoded message and decrypt it.
+  Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {
     let encoded = getMessageEncoding();
@@ -68,8 +67,8 @@
   }
 
   /*
-  Generate a sign/verify key, then set up event listeners
-  on the "Sign" and "Verify" buttons.
+  Generate an encryption key, then set up event listeners
+  on the "Encrypt" and "Decrypt" buttons.
   */
   window.crypto.subtle.generateKey(
     {

--- a/web-crypto/encrypt-decrypt/aes-cbc.js
+++ b/web-crypto/encrypt-decrypt/aes-cbc.js
@@ -1,7 +1,7 @@
 (() => {
 
   /*
-  Store the calculated ciphertext and IV here, so we can decrypt it later.
+  Store the calculated ciphertext and IV here, so we can decrypt the message later.
   */
   let ciphertext;
   let iv;

--- a/web-crypto/encrypt-decrypt/aes-ctr.js
+++ b/web-crypto/encrypt-decrypt/aes-ctr.js
@@ -34,13 +34,13 @@
       encoded
     );
 
-    let buffer = new Uint8Array(ciphertext, 0, 10);
+    let buffer = new Uint8Array(ciphertext, 0, 5);
     const ciphertextValue = document.querySelector(".aes-ctr .ciphertext-value");
     ciphertextValue.classList.add('fade-in');
     ciphertextValue.addEventListener('animationend', () => {
       ciphertextValue.classList.remove('fade-in');
     });
-    ciphertextValue.textContent = buffer;
+    ciphertextValue.textContent = `${buffer}...[${ciphertext.byteLength} bytes total]`;
   }
 
   /*

--- a/web-crypto/encrypt-decrypt/aes-ctr.js
+++ b/web-crypto/encrypt-decrypt/aes-ctr.js
@@ -1,0 +1,95 @@
+(() => {
+
+  /*
+  Store the calculated signature here, so we can verify it later.
+  */
+  let ciphertext;
+  let counter;
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for encrypt operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".aes-ctr #message");
+    let message = messageBox.value;
+    let enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message-to-sign, sign it and display a representation
+  of the first part of it in the "signature" element.
+  */
+  async function encryptMessage(key) {
+    let encoded = getMessageEncoding();
+    counter = window.crypto.getRandomValues(new Uint8Array(16)),
+    ciphertext = await window.crypto.subtle.encrypt(
+      {
+        name: "AES-CTR",
+        counter,
+        length: 64
+      },
+      key,
+      encoded
+    );
+
+    let buffer = new Uint8Array(ciphertext, 0, 10);
+    const ciphertextValue = document.querySelector(".aes-ctr .ciphertext-value");
+    ciphertextValue.classList.add('fade-in');
+    ciphertextValue.addEventListener('animationend', () => {
+      ciphertextValue.classList.remove('fade-in');
+    });
+    ciphertextValue.textContent = buffer;
+  }
+
+  /*
+  Fetch the encoded message-to-sign and verify it against the stored signature.
+  * If it checks out, set the "valid" class on the signature.
+  * Otherwise set the "invalid" class.
+  */
+  async function decryptMessage(key) {
+    let encoded = getMessageEncoding();
+    let decrypted = await window.crypto.subtle.decrypt(
+      {
+        name: "AES-CTR",
+        counter,
+        length: 64
+      },
+      key,
+      ciphertext
+    );
+
+    let dec = new TextDecoder();
+    const decryptedValue = document.querySelector(".aes-ctr .decrypted-value");
+    decryptedValue.classList.add('fade-in');
+    decryptedValue.addEventListener('animationend', () => {
+      decryptedValue.classList.remove('fade-in');
+    });
+    decryptedValue.textContent = dec.decode(decrypted);
+  }
+
+  /*
+  Generate a sign/verify key, then set up event listeners
+  on the "Sign" and "Verify" buttons.
+  */
+  window.crypto.subtle.generateKey(
+    {
+        name: "AES-CTR",
+        length: 256
+    },
+    true,
+    ["encrypt", "decrypt"]
+  ).then((key) => {
+    const encryptButton = document.querySelector(".aes-ctr .encrypt-button");
+    encryptButton.addEventListener("click", () => {
+      encryptMessage(key);
+    });
+
+    const decryptButton = document.querySelector(".aes-ctr .decrypt-button");
+    decryptButton.addEventListener("click", () => {
+      decryptMessage(key);
+    });
+  });
+
+})();

--- a/web-crypto/encrypt-decrypt/aes-ctr.js
+++ b/web-crypto/encrypt-decrypt/aes-ctr.js
@@ -11,7 +11,7 @@
   in a form we can use for the encrypt operation.
   */
   function getMessageEncoding() {
-    const messageBox = document.querySelector(".aes-ctr #message");
+    const messageBox = document.querySelector("#aes-ctr-message");
     let message = messageBox.value;
     let enc = new TextEncoder();
     return enc.encode(message);

--- a/web-crypto/encrypt-decrypt/aes-ctr.js
+++ b/web-crypto/encrypt-decrypt/aes-ctr.js
@@ -1,14 +1,14 @@
 (() => {
 
   /*
-  Store the calculated signature here, so we can verify it later.
+  Store the calculated ciphertext and counter here, so we can decrypt it later.
   */
   let ciphertext;
   let counter;
 
   /*
   Fetch the contents of the "message" textbox, and encode it
-  in a form we can use for encrypt operation.
+  in a form we can use for the encrypt operation.
   */
   function getMessageEncoding() {
     const messageBox = document.querySelector(".aes-ctr #message");
@@ -18,8 +18,8 @@
   }
 
   /*
-  Get the encoded message-to-sign, sign it and display a representation
-  of the first part of it in the "signature" element.
+  Get the encoded message, encrypt it and display a representation
+  of the ciphertext in the "Ciphertext" element.
   */
   async function encryptMessage(key) {
     let encoded = getMessageEncoding();
@@ -44,9 +44,8 @@
   }
 
   /*
-  Fetch the encoded message-to-sign and verify it against the stored signature.
-  * If it checks out, set the "valid" class on the signature.
-  * Otherwise set the "invalid" class.
+  Fetch the encoded message and decrypt it.
+  Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {
     let encoded = getMessageEncoding();
@@ -70,8 +69,8 @@
   }
 
   /*
-  Generate a sign/verify key, then set up event listeners
-  on the "Sign" and "Verify" buttons.
+  Generate an encryption key, then set up event listeners
+  on the "Encrypt" and "Decrypt" buttons.
   */
   window.crypto.subtle.generateKey(
     {

--- a/web-crypto/encrypt-decrypt/aes-ctr.js
+++ b/web-crypto/encrypt-decrypt/aes-ctr.js
@@ -23,6 +23,7 @@
   */
   async function encryptMessage(key) {
     let encoded = getMessageEncoding();
+    // The counter block value must never be reused with a given key.
     counter = window.crypto.getRandomValues(new Uint8Array(16)),
     ciphertext = await window.crypto.subtle.encrypt(
       {

--- a/web-crypto/encrypt-decrypt/aes-ctr.js
+++ b/web-crypto/encrypt-decrypt/aes-ctr.js
@@ -1,7 +1,7 @@
 (() => {
 
   /*
-  Store the calculated ciphertext and counter here, so we can decrypt it later.
+  Store the calculated ciphertext and counter here, so we can decrypt the message later.
   */
   let ciphertext;
   let counter;

--- a/web-crypto/encrypt-decrypt/aes-gcm.js
+++ b/web-crypto/encrypt-decrypt/aes-gcm.js
@@ -11,7 +11,7 @@
   in a form we can use for the encrypt operation.
   */
   function getMessageEncoding() {
-    const messageBox = document.querySelector(".aes-gcm #message");
+    const messageBox = document.querySelector("#aes-gcm-message");
     let message = messageBox.value;
     let enc = new TextEncoder();
     return enc.encode(message);

--- a/web-crypto/encrypt-decrypt/aes-gcm.js
+++ b/web-crypto/encrypt-decrypt/aes-gcm.js
@@ -33,13 +33,13 @@
       encoded
     );
 
-    let buffer = new Uint8Array(ciphertext, 0, 10);
+    let buffer = new Uint8Array(ciphertext, 0, 5);
     const ciphertextValue = document.querySelector(".aes-gcm .ciphertext-value");
     ciphertextValue.classList.add('fade-in');
     ciphertextValue.addEventListener('animationend', () => {
       ciphertextValue.classList.remove('fade-in');
     });
-    ciphertextValue.textContent = buffer;
+    ciphertextValue.textContent = `${buffer}...[${ciphertext.byteLength} bytes total]`;
   }
 
   /*

--- a/web-crypto/encrypt-decrypt/aes-gcm.js
+++ b/web-crypto/encrypt-decrypt/aes-gcm.js
@@ -1,0 +1,92 @@
+(() => {
+
+  /*
+  Store the calculated ciphertext and IV here, so we can decrypt it later.
+  */
+  let ciphertext;
+  let iv;
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for the encrypt operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".aes-gcm #message");
+    let message = messageBox.value;
+    let enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message, encrypt it and display a representation
+  of the ciphertext in the "Ciphertext" element.
+  */
+  async function encryptMessage(key) {
+    let encoded = getMessageEncoding();
+    iv = window.crypto.getRandomValues(new Uint8Array(12));
+    ciphertext = await window.crypto.subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv: iv
+      },
+      key,
+      encoded
+    );
+
+    let buffer = new Uint8Array(ciphertext, 0, 10);
+    const ciphertextValue = document.querySelector(".aes-gcm .ciphertext-value");
+    ciphertextValue.classList.add('fade-in');
+    ciphertextValue.addEventListener('animationend', () => {
+      ciphertextValue.classList.remove('fade-in');
+    });
+    ciphertextValue.textContent = buffer;
+  }
+
+  /*
+  Fetch the encoded message and decrypt it.
+  Write the decrypted message into the "Decrypted" box.
+  */
+  async function decryptMessage(key) {
+    let encoded = getMessageEncoding();
+    let decrypted = await window.crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: iv
+      },
+      key,
+      ciphertext
+    );
+
+    let dec = new TextDecoder();
+    const decryptedValue = document.querySelector(".aes-gcm .decrypted-value");
+    decryptedValue.classList.add('fade-in');
+    decryptedValue.addEventListener('animationend', () => {
+      decryptedValue.classList.remove('fade-in');
+    });
+    decryptedValue.textContent = dec.decode(decrypted);
+  }
+
+  /*
+  Generate an encryption key, then set up event listeners
+  on the "Encrypt" and "Decrypt" buttons.
+  */
+  window.crypto.subtle.generateKey(
+    {
+        name: "AES-GCM",
+        length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  ).then((key) => {
+    const encryptButton = document.querySelector(".aes-gcm .encrypt-button");
+    encryptButton.addEventListener("click", () => {
+      encryptMessage(key);
+    });
+
+    const decryptButton = document.querySelector(".aes-gcm .decrypt-button");
+    decryptButton.addEventListener("click", () => {
+      decryptMessage(key);
+    });
+  });
+
+})();

--- a/web-crypto/encrypt-decrypt/aes-gcm.js
+++ b/web-crypto/encrypt-decrypt/aes-gcm.js
@@ -23,6 +23,7 @@
   */
   async function encryptMessage(key) {
     let encoded = getMessageEncoding();
+    // The iv must never be reused with a given key.
     iv = window.crypto.getRandomValues(new Uint8Array(12));
     ciphertext = await window.crypto.subtle.encrypt(
       {

--- a/web-crypto/encrypt-decrypt/aes-gcm.js
+++ b/web-crypto/encrypt-decrypt/aes-gcm.js
@@ -1,7 +1,7 @@
 (() => {
 
   /*
-  Store the calculated ciphertext and IV here, so we can decrypt it later.
+  Store the calculated ciphertext and IV here, so we can decrypt the message later.
   */
   let ciphertext;
   let iv;

--- a/web-crypto/encrypt-decrypt/index.html
+++ b/web-crypto/encrypt-decrypt/index.html
@@ -42,8 +42,8 @@
           <h2 class="encrypt-decrypt-heading">RSA-OAEP</h2>
           <section class="encrypt-decrypt-controls">
             <div class="message-control">
-              <label for="message">Enter a message to encrypt:</label>
-              <input type="text" id="message" name="message" size="25"
+              <label for="rsa-oaep-message">Enter a message to encrypt:</label>
+              <input type="text" id="rsa-oaep-message" name="message" size="25"
                      value="The owl hoots at midnight">
             </div>
             <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
@@ -57,8 +57,8 @@
           <h2 class="encrypt-decrypt-heading">AES-CTR</h2>
           <section class="encrypt-decrypt-controls">
             <div class="message-control">
-              <label for="message">Enter a message to encrypt:</label>
-              <input type="text" id="message" name="message" size="25"
+              <label for="aes-ctr-message">Enter a message to encrypt:</label>
+              <input type="text" id="aes-ctr-message" name="message" size="25"
                      value="The tiger prowls at dawn">
             </div>
             <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
@@ -72,8 +72,8 @@
           <h2 class="encrypt-decrypt-heading">AES-CBC</h2>
           <section class="encrypt-decrypt-controls">
             <div class="message-control">
-              <label for="message">Enter a message to encrypt:</label>
-              <input type="text" id="message" name="message" size="25"
+              <label for="aes-cbc-message">Enter a message to encrypt:</label>
+              <input type="text" id="aes-cbc-message" name="message" size="25"
                      value="The eagle flies at twilight">
             </div>
             <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
@@ -87,8 +87,8 @@
           <h2 class="encrypt-decrypt-heading">AES-GCM</h2>
           <section class="encrypt-decrypt-controls">
             <div class="message-control">
-              <label for="message">Enter a message to encrypt:</label>
-              <input type="text" id="message" name="message" size="25"
+              <label for="aes-gcm-message">Enter a message to encrypt:</label>
+              <input type="text" id="aes-gcm-message" name="message" size="25"
                      value="The bunny hops at teatime">
             </div>
             <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>

--- a/web-crypto/encrypt-decrypt/index.html
+++ b/web-crypto/encrypt-decrypt/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Web Crypto API example</title>
+    <link rel="stylesheet" href="style.css">
+  </head>
+
+  <body>
+    <main>
+      <h1>Web Crypto: encrypt/decrypt</h1>
+
+      <section class="description">
+        <p>This page shows the use of the <code>encrypt()</code> and <code>decrypt()</code> functions of the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API">Web Crypto API</a>. It contains four separate examples, one for each encryption algorithm supported:</p>
+        <ul>
+          <li>"RSA-OAEP"</li>
+          <li>"AES-CTR"</li>
+          <li>"AES-CBC"</li>
+          <li>"AES-GCM"</li>
+        </ul>
+        <hr/>
+        <p>Each example has five components:</p>
+        <ul>
+          <li>A text box containing a message to encrypt.</li>
+          <li>A representation of the ciphertext.</li>
+          <li>A box that will contain the decrypted ciphertext.</li>
+          <li>An "Encrypt" button: this encrypts the text box contents, displays part of the ciphertext, and stores the complete ciphertext.</li>
+          <li>A "Decrypt" button: this decrypts the ciphertext and writes the result into the "Decrypted" box.</li>
+        </ul>
+        <p>Try it:</p>
+        <ul>
+          <li>Press "Encrypt". The ciphertext should appear.</li>
+          <li>Press "Decrypt". The decrypted text should appear, and match the original message.</li>
+          <li>Edit the text box contents.</li>
+          <li>Press "Encrypt" again. A different ciphertext should appear.</li>
+        </ul>
+      </section>
+
+      <section class="examples">
+        <section class="encrypt-decrypt rsa-oaep">
+          <h2 class="encrypt-decrypt-heading">RSA-OAEP</h2>
+          <section class="encrypt-decrypt-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to encrypt:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The owl hoots at midnight">
+            </div>
+            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
+            <div class="decrypted">Decrypted:<span class="decrypted-value"></span></div>
+            <input class="encrypt-button" type="button" value="Encrypt">
+            <input class="decrypt-button" type="button" value="Decrypt">
+          </section>
+        </section>
+
+        <section class="encrypt-decrypt aes-ctr">
+          <h2 class="encrypt-decrypt-heading">AES-CTR</h2>
+          <section class="encrypt-decrypt-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to encrypt:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The tiger prowls at dawn">
+            </div>
+            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
+            <div class="decrypted">Decrypted:<span class="decrypted-value"></span></div>
+            <input class="encrypt-button" type="button" value="Encrypt">
+            <input class="decrypt-button" type="button" value="Decrypt">
+          </section>
+        </section>
+
+        <section class="encrypt-decrypt aes-cbc">
+          <h2 class="encrypt-decrypt-heading">AES-CBC</h2>
+          <section class="encrypt-decrypt-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to encrypt:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The eagle flies at twilight">
+            </div>
+            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
+            <div class="decrypted">Decrypted:<span class="decrypted-value"></span></div>
+            <input class="encrypt-button" type="button" value="Encrypt">
+            <input class="decrypt-button" type="button" value="Decrypt">
+          </section>
+        </section>
+
+        <section class="encrypt-decrypt aes-gcm">
+          <h2 class="encrypt-decrypt-heading">AES-GCM</h2>
+          <section class="encrypt-decrypt-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to encrypt:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The bunny hops at teatime">
+            </div>
+            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
+            <div class="decrypted">Decrypted:<span class="decrypted-value"></span></div>
+            <input class="encrypt-button" type="button" value="Encrypt">
+            <input class="decrypt-button" type="button" value="Decrypt">
+          </section>
+        </section>
+
+      </section>
+    </main>
+
+  </body>
+  <script src="rsa-oaep.js"></script>
+  <script src="aes-cbc.js"></script>
+  <script src="aes-ctr.js"></script>
+  <script src="aes-gcm.js"></script>
+</html>

--- a/web-crypto/encrypt-decrypt/index.html
+++ b/web-crypto/encrypt-decrypt/index.html
@@ -33,6 +33,7 @@
           <li>Press "Decrypt". The decrypted text should appear, and match the original message.</li>
           <li>Edit the text box contents.</li>
           <li>Press "Encrypt" again. A different ciphertext should appear.</li>
+          <li>Press "Decrypt" again. The new text box contents should appear next to "Decrypted:".</li>
         </ul>
       </section>
 

--- a/web-crypto/encrypt-decrypt/rsa-oaep.js
+++ b/web-crypto/encrypt-decrypt/rsa-oaep.js
@@ -10,7 +10,7 @@
   in a form we can use for the encrypt operation.
   */
   function getMessageEncoding() {
-    const messageBox = document.querySelector(".rsa-oaep #message");
+    const messageBox = document.querySelector("#rsa-oaep-message");
     let message = messageBox.value;
     let enc = new TextEncoder();
     return enc.encode(message);

--- a/web-crypto/encrypt-decrypt/rsa-oaep.js
+++ b/web-crypto/encrypt-decrypt/rsa-oaep.js
@@ -1,0 +1,91 @@
+(() => {
+
+  /*
+  Store the calculated ciphertext and IV here, so we can decrypt it later.
+  */
+  let ciphertext;
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for the encrypt operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".rsa-oaep #message");
+    let message = messageBox.value;
+    let enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message, encrypt it and display a representation
+  of the ciphertext in the "Ciphertext" element.
+  */
+  async function encryptMessage(key) {
+    let encoded = getMessageEncoding();
+    ciphertext = await window.crypto.subtle.encrypt(
+      {
+        name: "RSA-OAEP"
+      },
+      key,
+      encoded
+    );
+
+    let buffer = new Uint8Array(ciphertext, 0, 10);
+    const ciphertextValue = document.querySelector(".rsa-oaep .ciphertext-value");
+    ciphertextValue.classList.add('fade-in');
+    ciphertextValue.addEventListener('animationend', () => {
+      ciphertextValue.classList.remove('fade-in');
+    });
+    ciphertextValue.textContent = buffer;
+  }
+
+  /*
+  Fetch the encoded message and decrypt it.
+  Write the decrypted message into the "Decrypted" box.
+  */
+  async function decryptMessage(key) {
+    let encoded = getMessageEncoding();
+    let decrypted = await window.crypto.subtle.decrypt(
+      {
+        name: "RSA-OAEP"
+      },
+      key,
+      ciphertext
+    );
+
+    let dec = new TextDecoder();
+    const decryptedValue = document.querySelector(".rsa-oaep .decrypted-value");
+    decryptedValue.classList.add('fade-in');
+    decryptedValue.addEventListener('animationend', () => {
+      decryptedValue.classList.remove('fade-in');
+    });
+    decryptedValue.textContent = dec.decode(decrypted);
+  }
+
+  /*
+  Generate an encryption key pair, then set up event listeners
+  on the "Encrypt" and "Decrypt" buttons.
+  */
+  window.crypto.subtle.generateKey(
+    {
+    name: "RSA-OAEP",
+    // Consider using a 4096-bit key for systems that require long-term security
+    modulusLength: 2048,
+    publicExponent: new Uint8Array([1, 0, 1]),
+    hash: "SHA-256",
+    },
+    true,
+    ["encrypt", "decrypt"]
+  ).then((keyPair) => {
+    const encryptButton = document.querySelector(".rsa-oaep .encrypt-button");
+    encryptButton.addEventListener("click", () => {
+      encryptMessage(keyPair.publicKey);
+    });
+
+    const decryptButton = document.querySelector(".rsa-oaep .decrypt-button");
+    decryptButton.addEventListener("click", () => {
+      decryptMessage(keyPair.privateKey);
+    });
+  });
+
+})();

--- a/web-crypto/encrypt-decrypt/rsa-oaep.js
+++ b/web-crypto/encrypt-decrypt/rsa-oaep.js
@@ -1,7 +1,7 @@
 (() => {
 
   /*
-  Store the calculated ciphertext and IV here, so we can decrypt it later.
+  Store the calculated ciphertext here, so we can decrypt it later.
   */
   let ciphertext;
 

--- a/web-crypto/encrypt-decrypt/rsa-oaep.js
+++ b/web-crypto/encrypt-decrypt/rsa-oaep.js
@@ -1,7 +1,7 @@
 (() => {
 
   /*
-  Store the calculated ciphertext here, so we can decrypt it later.
+  Store the calculated ciphertext here, so we can decrypt the message later.
   */
   let ciphertext;
 

--- a/web-crypto/encrypt-decrypt/rsa-oaep.js
+++ b/web-crypto/encrypt-decrypt/rsa-oaep.js
@@ -30,13 +30,13 @@
       encoded
     );
 
-    let buffer = new Uint8Array(ciphertext, 0, 10);
+    let buffer = new Uint8Array(ciphertext, 0, 5);
     const ciphertextValue = document.querySelector(".rsa-oaep .ciphertext-value");
     ciphertextValue.classList.add('fade-in');
     ciphertextValue.addEventListener('animationend', () => {
       ciphertextValue.classList.remove('fade-in');
     });
-    ciphertextValue.textContent = buffer;
+    ciphertextValue.textContent = `${buffer}...[${ciphertext.byteLength} bytes total]`;
   }
 
   /*

--- a/web-crypto/encrypt-decrypt/style.css
+++ b/web-crypto/encrypt-decrypt/style.css
@@ -65,7 +65,7 @@ h1 {
     grid-row: 2;
 }
 
-/* sign-verify controls grid */
+/* encrypt-decrypt controls grid */
 .encrypt-decrypt-controls {
     display: grid;
     grid-template-columns: 1fr 5rem;

--- a/web-crypto/encrypt-decrypt/style.css
+++ b/web-crypto/encrypt-decrypt/style.css
@@ -1,0 +1,112 @@
+/* General setup */
+
+* {
+    box-sizing: border-box;
+}
+
+html,body {
+    font-family: sans-serif;
+    line-height: 1.2rem;
+}
+
+/* Layout and styles */
+
+h1 {
+    color: green;
+    margin-left: .5rem;
+}
+
+.description, .encrypt-decrypt {
+    margin: 0 .5rem;
+}
+
+.description > p {
+    margin-top: 0;
+}
+
+.encrypt-decrypt {
+    box-shadow: -1px 2px 5px gray;
+    padding: .2rem .5rem;
+    margin-bottom: 2rem;
+}
+
+.encrypt-decrypt-controls > * {
+    margin: .5rem 0;
+}
+
+input[type="button"] {
+    width: 5rem;
+}
+
+.ciphertext-value, .decrypted-value {
+    padding-left: .5rem;
+    font-family: monospace;
+}
+
+/* Whole page grid */
+main {
+    display: grid;
+    grid-template-columns: 32rem 1fr;
+    grid-template-rows: 4rem 1fr;
+}
+
+h1 {
+    grid-column: 1/2;
+    grid-row: 1;
+}
+
+.examples {
+    grid-column: 1;
+    grid-row: 2;
+}
+
+.description {
+    grid-column: 2;
+    grid-row: 2;
+}
+
+/* sign-verify controls grid */
+.encrypt-decrypt-controls {
+    display: grid;
+    grid-template-columns: 1fr 5rem;
+    grid-template-rows: 1fr 1fr 1fr;
+}
+
+.message-control {
+    grid-column-start: 1;
+    grid-row-start: 1;
+}
+
+.ciphertext {
+    grid-column-start: 1;
+    grid-row-start: 2;
+}
+
+.decrypted {
+    grid-column-start: 1;
+    grid-row-start: 3;
+}
+
+.encrypt-button {
+    grid-column-start: 2;
+    grid-row-start: 1;
+}
+
+.decrypt-button {
+    grid-column-start: 2;
+    grid-row-start: 2;
+}
+
+/* Animate output display */
+.fade-in {
+    animation: fadein .5s;
+}
+
+@keyframes fadein {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}

--- a/web-crypto/sign-verify/ecdsa.js
+++ b/web-crypto/sign-verify/ecdsa.js
@@ -38,8 +38,8 @@
     signatureValue.addEventListener('animationend', () => {
       signatureValue.classList.remove('fade-in');
     });
-    let buffer = new Uint8Array(signature, 0, 10);
-    signatureValue.textContent = buffer;
+    let buffer = new Uint8Array(signature, 0, 5);
+    signatureValue.textContent = `${buffer}...[${signature.byteLength} bytes total]`;
   }
 
   /*

--- a/web-crypto/sign-verify/hmac.js
+++ b/web-crypto/sign-verify/hmac.js
@@ -35,8 +35,8 @@
     signatureValue.addEventListener('animationend', () => {
       signatureValue.classList.remove('fade-in');
     });
-    let buffer = new Uint8Array(signature, 0, 10);
-    signatureValue.textContent = buffer;
+    let buffer = new Uint8Array(signature, 0, 5);
+    signatureValue.textContent = `${buffer}...[${signature.byteLength} bytes total]`;
   }
 
   /*

--- a/web-crypto/sign-verify/rsa-pss.js
+++ b/web-crypto/sign-verify/rsa-pss.js
@@ -38,8 +38,8 @@
     signatureValue.addEventListener('animationend', () => {
       signatureValue.classList.remove('fade-in');
     });
-    let buffer = new Uint8Array(signature, 0, 10);
-    signatureValue.textContent = buffer;
+    let buffer = new Uint8Array(signature, 0, 5);
+    signatureValue.textContent = `${buffer}...[${signature.byteLength} bytes total]`;
   }
 
   /*

--- a/web-crypto/sign-verify/rsassa-pkcs1.js
+++ b/web-crypto/sign-verify/rsassa-pkcs1.js
@@ -35,8 +35,8 @@
     signatureValue.addEventListener('animationend', () => {
       signatureValue.classList.remove('fade-in');
     });
-    let buffer = new Uint8Array(signature, 0, 10);
-    signatureValue.textContent = buffer;
+    let buffer = new Uint8Array(signature, 0, 5);
+    signatureValue.textContent = `${buffer}...[${signature.byteLength} bytes total]`;
   }
 
   /*

--- a/web-crypto/sign-verify/style.css
+++ b/web-crypto/sign-verify/style.css
@@ -40,7 +40,7 @@ input[type="button"] {
 
 .signature-value {
     padding-left: .5rem;
-    font-size: .8rem;
+    font-family: monospace;
 }
 
 /* Validity CSS */


### PR DESCRIPTION
@april , @chrisdavidmills - here's a PR adding examples of encrypt/decrypt for the 4 encryption algorithms supported by the Web Crypto API:

* RSA-OAEP
* AES-CTR
* AES-CBC
* AES-GCM

It follows very closely the structure of the previous PR for sign/verify.

In particular I'm interested in knowing whether I've got the params right for the encrypt operations, especially for AES-CTR, which I found a bit obscure. The values I've used come from my reading of [Appendix B of the NIST SP800-38A standard](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf#%5B%7B%22num%22%3A70%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22Fit%22%7D%5D), which I've tried to document here: https://developer.mozilla.org/en-US/docs/Web/API/AesCtrParams. But of course it's possible I've made some horrible errors.