### PR TITLE
Add examples for importKey and exportKey

### DIFF
--- a/web-crypto/export-key/index.html
+++ b/web-crypto/export-key/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Web Crypto API example</title>
+    <link rel="stylesheet" href="style.css">
+  </head>
+
+  <body>
+    <main>
+      <h1>Web Crypto: exportKey</h1>
+
+      <section class="description">
+        <p>This page shows the use of the <code>exportKey()</code> function of the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API">Web Crypto API</a>.</p>
+        <p>On page load, it generates four keys:</p>
+        <ul>
+          <li>An AES-GCM secret key</li>
+          <li>An RSA-PSS signing key pair</li>
+          <li>An RSA-OAEP encryption key pair</li>
+          <li>An ECDSA signing key pair</li>
+        </ul>
+        <p>It provides four buttons across the top:</p>
+        <ul>
+          <li>Export the AES-GCM key in raw format</li>
+          <li>Export the RSA-PSS private key in PKCS #8 format</li>
+          <li>Export the RSA-OAEP public key in SubjectPublicKeyInfo format</li>
+          <li>Export the ECDSA private key in JWK format</li>
+        </ul>
+        <p>The exported key is written to the area below the buttons. PKCS #8 and SubjectPublicKeyInfo formats are further encoded as PEM objects.</p>
+      </section>
+
+      <section class="examples">
+        <section class="buttons">
+          <input class="raw export-key-button" type="button" value="Export AES-GCM key as raw">
+          <input class="pkcs8 export-key-button" type="button" value="Export RSA-PSS key as PKCS #8">
+          <input class="spki export-key-button" type="button" value="Export RSA-OAEP key as SPKI">
+          <input class="jwk export-key-button" type="button" value="Export ECDSA key as JWK">
+        </section>
+        <section class="output">
+          <pre class="exported-key"></pre>
+        </section>
+      </section>
+
+    </main>
+
+  </body>
+  <script src="raw.js"></script>
+  <script src="pkcs8.js"></script>
+  <script src="spki.js"></script>
+  <script src="jwk.js"></script>
+</html>

--- a/web-crypto/export-key/jwk.js
+++ b/web-crypto/export-key/jwk.js
@@ -1,0 +1,38 @@
+(() => {
+
+  /*
+  Export the given key and write it into the "exported-key" space.
+  */
+  async function exportCryptoKey(key) {
+    const exported = await window.crypto.subtle.exportKey(
+      "jwk",
+      key
+    );
+    const exportKeyOutput = document.querySelector(".exported-key");
+    exportKeyOutput.classList.add("fade-in");
+    exportKeyOutput.addEventListener("animationend", () => {
+      exportKeyOutput.classList.remove("fade-in");
+    });
+    exportKeyOutput.textContent = JSON.stringify(exported, null, " ");
+  }
+
+  /*
+  Generate a sign/verify key pair,
+  then set up an event listener on the "Export" button.
+  */
+  window.crypto.subtle.generateKey(
+    {
+      name: "ECDSA",
+      namedCurve: "P-384"
+    },
+    true,
+    ["sign", "verify"]
+  ).then((keyPair) => {
+    const exportButton = document.querySelector(".jwk");
+    exportButton.addEventListener("click", () => {
+      exportCryptoKey(keyPair.privateKey);
+    });
+
+  });
+
+})();

--- a/web-crypto/export-key/pkcs8.js
+++ b/web-crypto/export-key/pkcs8.js
@@ -1,0 +1,53 @@
+(() => {
+
+  /*
+  Convert  an ArrayBuffer into a string
+  from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
+  */
+  function ab2str(buf) {
+    return String.fromCharCode.apply(null, new Uint8Array(buf));
+  }
+
+  /*
+  Export the given key and write it into the "exported-key" space.
+  */
+  async function exportCryptoKey(key) {
+    const exported = await window.crypto.subtle.exportKey(
+      "pkcs8",
+      key
+    );
+    const exportedAsString = ab2str(exported);
+    const exportedAsBase64 = window.btoa(exportedAsString);
+    const pemExported = `-----BEGIN PRIVATE KEY-----\n${exportedAsBase64}\n-----END PRIVATE KEY-----`;
+
+    const exportKeyOutput = document.querySelector(".exported-key");
+    exportKeyOutput.classList.add("fade-in");
+    exportKeyOutput.addEventListener("animationend", () => {
+      exportKeyOutput.classList.remove("fade-in");
+    });
+    exportKeyOutput.textContent = pemExported;
+  }
+
+  /*
+  Generate a sign/verify key pair,
+  then set up an event listener on the "Export" button.
+  */
+  window.crypto.subtle.generateKey(
+    {
+      name: "RSA-PSS",
+      // Consider using a 4096-bit key for systems that require long-term security
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  ).then((keyPair) => {
+    const exportButton = document.querySelector(".pkcs8");
+    exportButton.addEventListener("click", () => {
+      exportCryptoKey(keyPair.privateKey);
+    });
+
+  });
+
+})();

--- a/web-crypto/export-key/raw.js
+++ b/web-crypto/export-key/raw.js
@@ -1,0 +1,40 @@
+(() => {
+
+  /*
+  Export the given key and write it into the "exported-key" space.
+  */
+  async function exportCryptoKey(key) {
+    const exported = await window.crypto.subtle.exportKey(
+      "raw",
+      key
+    );
+    const exportedKeyBuffer = new Uint8Array(exported);
+
+    const exportKeyOutput = document.querySelector(".exported-key");
+    exportKeyOutput.classList.add("fade-in");
+    exportKeyOutput.addEventListener("animationend", () => {
+      exportKeyOutput.classList.remove("fade-in");
+    });
+    exportKeyOutput.textContent = `[${exportedKeyBuffer}]`;
+  }
+
+  /*
+  Generate an encrypt/decrypt secret key,
+  then set up an event listener on the "Export" button.
+  */
+  window.crypto.subtle.generateKey(
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  ).then((key) => {
+    const exportButton = document.querySelector(".raw");
+    exportButton.addEventListener("click", () => {
+      exportCryptoKey(key);
+    });
+
+  });
+
+})();

--- a/web-crypto/export-key/spki.js
+++ b/web-crypto/export-key/spki.js
@@ -1,0 +1,53 @@
+(() => {
+
+  /*
+  Convert  an ArrayBuffer into a string
+  from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
+  */
+  function ab2str(buf) {
+    return String.fromCharCode.apply(null, new Uint8Array(buf));
+  }
+
+  /*
+  Export the given key and write it into the "exported-key" space.
+  */
+  async function exportCryptoKey(key) {
+    const exported = await window.crypto.subtle.exportKey(
+      "spki",
+      key
+    );
+    const exportedAsString = ab2str(exported);
+    const exportedAsBase64 = window.btoa(exportedAsString);
+    const pemExported = `-----BEGIN PUBLIC KEY-----\n${exportedAsBase64}\n-----END PUBLIC KEY-----`;
+
+    const exportKeyOutput = document.querySelector(".exported-key");
+    exportKeyOutput.classList.add("fade-in");
+    exportKeyOutput.addEventListener("animationend", () => {
+      exportKeyOutput.classList.remove("fade-in");
+    });
+    exportKeyOutput.textContent = pemExported;
+  }
+
+  /*
+  Generate an encrypt/decrypt key pair,
+  then set up an event listener on the "Export" button.
+  */
+  window.crypto.subtle.generateKey(
+    {
+      name: "RSA-OAEP",
+      // Consider using a 4096-bit key for systems that require long-term security
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["encrypt", "decrypt"]
+  ).then((keyPair) => {
+    const exportButton = document.querySelector(".spki");
+    exportButton.addEventListener("click", () => {
+      exportCryptoKey(keyPair.publicKey);
+    });
+
+  });
+
+})();

--- a/web-crypto/export-key/style.css
+++ b/web-crypto/export-key/style.css
@@ -38,7 +38,7 @@ h1 {
 /* Whole page grid */
 main {
     display: grid;
-    grid-template-columns: 45rem 1fr;
+    grid-template-columns: 48rem 1fr;
     grid-template-rows: 4rem 1fr;
 }
 

--- a/web-crypto/export-key/style.css
+++ b/web-crypto/export-key/style.css
@@ -1,0 +1,72 @@
+/* General setup */
+
+* {
+    box-sizing: border-box;
+}
+
+html,body {
+    font-family: sans-serif;
+    line-height: 1.2rem;
+}
+
+/* Layout and styles */
+
+h1 {
+    color: green;
+    margin-left: .5rem;
+}
+
+.description, .examples {
+    margin: 0 .5rem;
+}
+
+.description > p {
+    margin-top: 0;
+}
+
+.output {
+    box-shadow: inset 0 0 3px 1px black;
+    height: 100%;
+}
+
+.exported-key {
+    padding: 1em;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+/* Whole page grid */
+main {
+    display: grid;
+    grid-template-columns: 45rem 1fr;
+    grid-template-rows: 4rem 1fr;
+}
+
+h1 {
+    grid-column: 1/2;
+    grid-row: 1;
+}
+
+.examples {
+    grid-column: 1;
+    grid-row: 2;
+}
+
+.description {
+    grid-column: 2;
+    grid-row: 2;
+}
+
+/* Animate output display */
+.fade-in {
+    animation: fadein .5s;
+}
+
+@keyframes fadein {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}

--- a/web-crypto/import-key/index.html
+++ b/web-crypto/import-key/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Web Crypto API example</title>
+    <link rel="stylesheet" href="style.css">
+  </head>
+
+  <body>
+    <main>
+      <h1>Web Crypto: importKey</h1>
+
+      <section class="description">
+        <p>This page shows the use of the <code>importKey()</code> function of the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API">Web Crypto API</a>. It contains four separate examples, one for each import format supported:</p>
+        <ul>
+          <li>Raw</li>
+          <li>PKCS #8</li>
+          <li>SubjectPublicKeyInfo</li>
+          <li>JSON Web Key</li>
+        </ul>
+        <p>Each example has the same structure: you get a message and two buttons, one labeled "Import Key" and the other labeled either "Sign" or "Encrypt", depending on the type of key we are importing. The "Sign"/"Encrypt" button is disabled initially.</p>
+        <p>If you click "Import Key" then the example imports a particular key:</p>
+        <ul>
+          <li>For "Raw", an AES encryption key.</li>
+          <li>For "PKCS #8", an RSA private signing key.</li>
+          <li>For "SubjectPublicKeyInfo", an RSA public encryption key.</li>
+          <li>For "JSON Web Key", an EC private signing key.</li>
+        </ul>
+        <p>The "Sign"/"Encrypt" button is then enabled, and you can click it to use the imported key to perform the appropriate operation and display the result.</p>
+      </section>
+
+      <section class="examples">
+
+        <section class="import-key raw">
+          <h2 class="import-key-heading">Raw</h2>
+          <section class="import-key-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to encrypt:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The owl hoots at midnight">
+            </div>
+            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
+            <input class="import-key-button" type="button" value="Import Key">
+            <input class="encrypt-button" type="button" value="Encrypt" disabled>
+          </section>
+        </section>
+
+        <section class="import-key pkcs8">
+          <h2 class="import-key-heading">PKCS #8</h2>
+          <section class="import-key-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to sign:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The tiger prowls at dawn">
+            </div>
+            <div class="signature">Signature:<span class="signature-value"></span></div>
+            <input class="import-key-button" type="button" value="Import Key">
+            <input class="sign-button" type="button" value="Sign" disabled>
+          </section>
+        </section>
+
+        <section class="import-key spki">
+          <h2 class="import-key-heading">SubjectPublicKeyInfo</h2>
+          <section class="import-key-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to encrypt:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The eagle flies at twilight">
+            </div>
+            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
+            <input class="import-key-button" type="button" value="Import Key">
+            <input class="encrypt-button" type="button" value="Encrypt" disabled>
+          </section>
+        </section>
+
+        <section class="import-key jwk">
+          <h2 class="import-key-heading">JSON Web Key</h2>
+          <section class="import-key-controls">
+            <div class="message-control">
+              <label for="message">Enter a message to sign:</label>
+              <input type="text" id="message" name="message" size="25"
+                     value="The bunny hops at teatime">
+            </div>
+            <div class="signature">Signature:<span class="signature-value"></span></div>
+            <input class="import-key-button" type="button" value="Import Key">
+            <input class="sign-button" type="button" value="Sign" disabled>
+          </section>
+        </section>
+
+      </section>
+    </main>
+
+  </body>
+  <script src="raw.js"></script>
+  <script src="pkcs8.js"></script>
+  <script src="spki.js"></script>
+  <script src="jwk.js"></script>
+</html>

--- a/web-crypto/import-key/index.html
+++ b/web-crypto/import-key/index.html
@@ -18,7 +18,7 @@
           <li>SubjectPublicKeyInfo</li>
           <li>JSON Web Key</li>
         </ul>
-        <p>Each example has the same structure: you get a message and two buttons, one labeled "Import Key" and the other labeled either "Sign" or "Encrypt", depending on the type of key we are importing. The "Sign"/"Encrypt" button is disabled initially.</p>
+        <p>Each example has the same structure: you get a message a button labeled "Import Key".</p>
         <p>If you click "Import Key" then the example imports a particular key:</p>
         <ul>
           <li>For "Raw", an AES encryption key.</li>
@@ -26,7 +26,7 @@
           <li>For "SubjectPublicKeyInfo", an RSA public encryption key.</li>
           <li>For "JSON Web Key", an EC private signing key.</li>
         </ul>
-        <p>The "Sign"/"Encrypt" button is then enabled, and you can click it to use the imported key to perform the appropriate operation and display the result.</p>
+        <p>A new button is then displayed, labeled "Sign" or "Encrypt", depending on the key that was imported. You can click it to use the imported key to perform the appropriate operation and display the result.</p>
       </section>
 
       <section class="examples">
@@ -41,7 +41,7 @@
             </div>
             <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
             <input class="import-key-button" type="button" value="Import Key">
-            <input class="encrypt-button" type="button" value="Encrypt" disabled>
+            <input class="encrypt-button hidden" type="button" value="Encrypt" disabled>
           </section>
         </section>
 
@@ -55,7 +55,7 @@
             </div>
             <div class="signature">Signature:<span class="signature-value"></span></div>
             <input class="import-key-button" type="button" value="Import Key">
-            <input class="sign-button" type="button" value="Sign" disabled>
+            <input class="sign-button hidden" type="button" value="Sign" disabled>
           </section>
         </section>
 
@@ -69,7 +69,7 @@
             </div>
             <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
             <input class="import-key-button" type="button" value="Import Key">
-            <input class="encrypt-button" type="button" value="Encrypt" disabled>
+            <input class="encrypt-button hidden" type="button" value="Encrypt" disabled>
           </section>
         </section>
 
@@ -83,7 +83,7 @@
             </div>
             <div class="signature">Signature:<span class="signature-value"></span></div>
             <input class="import-key-button" type="button" value="Import Key">
-            <input class="sign-button" type="button" value="Sign" disabled>
+            <input class="sign-button hidden" type="button" value="Sign" disabled>
           </section>
         </section>
 

--- a/web-crypto/import-key/index.html
+++ b/web-crypto/import-key/index.html
@@ -35,8 +35,8 @@
           <h2 class="import-key-heading">Raw</h2>
           <section class="import-key-controls">
             <div class="message-control">
-              <label for="message">Enter a message to encrypt:</label>
-              <input type="text" id="message" name="message" size="25"
+              <label for="raw-message">Enter a message to encrypt:</label>
+              <input type="text" id="raw-message" name="message" size="25"
                      value="The owl hoots at midnight">
             </div>
             <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
@@ -49,8 +49,8 @@
           <h2 class="import-key-heading">PKCS #8</h2>
           <section class="import-key-controls">
             <div class="message-control">
-              <label for="message">Enter a message to sign:</label>
-              <input type="text" id="message" name="message" size="25"
+              <label for="pkcs8-message">Enter a message to sign:</label>
+              <input type="text" id="pkcs8-message" name="message" size="25"
                      value="The tiger prowls at dawn">
             </div>
             <div class="signature">Signature:<span class="signature-value"></span></div>
@@ -63,8 +63,8 @@
           <h2 class="import-key-heading">SubjectPublicKeyInfo</h2>
           <section class="import-key-controls">
             <div class="message-control">
-              <label for="message">Enter a message to encrypt:</label>
-              <input type="text" id="message" name="message" size="25"
+              <label for="spki-message">Enter a message to encrypt:</label>
+              <input type="text" id="spki-message" name="message" size="25"
                      value="The eagle flies at twilight">
             </div>
             <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
@@ -77,8 +77,8 @@
           <h2 class="import-key-heading">JSON Web Key</h2>
           <section class="import-key-controls">
             <div class="message-control">
-              <label for="message">Enter a message to sign:</label>
-              <input type="text" id="message" name="message" size="25"
+              <label for="jwk-message">Enter a message to sign:</label>
+              <input type="text" id="jwk-message" name="message" size="25"
                      value="The bunny hops at teatime">
             </div>
             <div class="signature">Signature:<span class="signature-value"></span></div>

--- a/web-crypto/import-key/jwk.js
+++ b/web-crypto/import-key/jwk.js
@@ -33,7 +33,7 @@
     in a form we can use for the sign operation.
     */
     function getMessageEncoding() {
-      const messageBox = document.querySelector(".jwk #message");
+      const messageBox = document.querySelector("#jwk-message");
       const message = messageBox.value;
       const enc = new TextEncoder();
       return enc.encode(message);

--- a/web-crypto/import-key/jwk.js
+++ b/web-crypto/import-key/jwk.js
@@ -11,6 +11,13 @@
     };
 
     /*
+    The unwrapped signing key.
+    */
+    let signingKey;
+
+    const signButton = document.querySelector(".jwk .sign-button");
+
+    /*
     Import a JSON Web Key format EC private key, to use for ECDSA signing.
     Takes a string containing the JSON Web Key, and returns a Promise
     that will resolve to a CryptoKey representing the private key.
@@ -43,14 +50,14 @@
     Get the encoded message-to-sign, sign it and display a representation
     of the first part of it in the "signature" element.
     */
-    async function signMessage(privateKey) {
+    async function signMessage() {
       const encoded = getMessageEncoding();
       const signature = await window.crypto.subtle.sign(
         {
           name: "ECDSA",
           hash: "SHA-512"
         },
-        privateKey,
+        signingKey,
         encoded
       );
 
@@ -64,19 +71,28 @@
     }
 
     /*
+    Show and enable the sign button.
+    */
+    function enableSignButton() {
+      signButton.classList.add('fade-in');
+      signButton.addEventListener('animationend', () => {
+        signButton.classList.remove('fade-in');
+      });
+      signButton.removeAttribute("disabled");
+      signButton.classList.remove("hidden");
+    }
+
+    /*
     When the user clicks "Import Key"
     - import the key
     - enable the "Sign" button
-    - add a listener to "Sign" that uses the key.
     */
     const importKeyButton = document.querySelector(".jwk .import-key-button");
     importKeyButton.addEventListener("click", async () => {
-      const privateKey = await importPrivateKey(jwkEcKey);
-      const signButton = document.querySelector(".jwk .sign-button");
-      signButton.removeAttribute("disabled");
-      signButton.addEventListener("click", () => {
-        signMessage(privateKey);
-      });
+      signingKey = await importPrivateKey(jwkEcKey);
+      enableSignButton();
     });
+
+    signButton.addEventListener("click", signMessage);
 
 })();

--- a/web-crypto/import-key/jwk.js
+++ b/web-crypto/import-key/jwk.js
@@ -1,0 +1,82 @@
+(() => {
+
+    const jwkEcKey = {
+      "crv": "P-384",
+      "d": "wouCtU7Nw4E8_7n5C1-xBjB4xqSb_liZhYMsy8MGgxUny6Q8NCoH9xSiviwLFfK_",
+      "ext": true,
+      "key_ops": ["sign"],
+      "kty": "EC",
+      "x": "SzrRXmyI8VWFJg1dPUNbFcc9jZvjZEfH7ulKI1UkXAltd7RGWrcfFxqyGPcwu6AQ",
+      "y": "hHUag3OvDzEr0uUQND4PXHQTXP5IDGdYhJhL-WLKjnGjQAw0rNGy5V29-aV-yseW"
+    };
+
+    /*
+    Import a JSON Web Key format EC private key, to use for ECDSA signing.
+    Takes a string containing the JSON Web Key, and returns a Promise
+    that will resolve to a CryptoKey representing the private key.
+    */
+    function importPrivateKey(jwk) {
+      return window.crypto.subtle.importKey(
+        "jwk",
+        jwk,
+        {
+          name: "ECDSA",
+          namedCurve: "P-384"
+        },
+        true,
+        ["sign"]
+      );
+    }
+
+    /*
+    Fetch the contents of the "message" textbox, and encode it
+    in a form we can use for the sign operation.
+    */
+    function getMessageEncoding() {
+      const messageBox = document.querySelector(".jwk #message");
+      const message = messageBox.value;
+      const enc = new TextEncoder();
+      return enc.encode(message);
+    }
+
+    /*
+    Get the encoded message-to-sign, sign it and display a representation
+    of the first part of it in the "signature" element.
+    */
+    async function signMessage(privateKey) {
+      const encoded = getMessageEncoding();
+      const signature = await window.crypto.subtle.sign(
+        {
+          name: "ECDSA",
+          hash: "SHA-512"
+        },
+        privateKey,
+        encoded
+      );
+
+      const signatureValue = document.querySelector(".jwk .signature-value");
+      signatureValue.classList.add('fade-in');
+      signatureValue.addEventListener('animationend', () => {
+        signatureValue.classList.remove('fade-in');
+      });
+      const buffer = new Uint8Array(signature, 0, 5);
+      signatureValue.textContent = `${buffer}...[${signature.byteLength} bytes total]`;
+    }
+
+    /*
+    When the user clicks "Import Key"
+    - import the key
+    - enable the "Sign" button
+    - add a listener to "Sign" that uses the key.
+    */
+    const importKeyButton = document.querySelector(".jwk .import-key-button");
+    importKeyButton.addEventListener("click", async () => {
+      const privateKey = await importPrivateKey(jwkEcKey);
+      const signButton = document.querySelector(".jwk .sign-button");
+      signButton.removeAttribute("disabled");
+      signButton.addEventListener("click", () => {
+        signMessage(privateKey);
+      });
+    });
+
+})();

--- a/web-crypto/import-key/pkcs8.js
+++ b/web-crypto/import-key/pkcs8.js
@@ -1,5 +1,16 @@
 (() => {
 
+  const pemEncodedKey = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDD0tPV/du2vftjvXj1t/gXTK39sNBVrOAEb/jKzXae+Xa0H+3LhZaQIQNMfACiBSgIfZUvEGb+7TqXWQpoLoFR/R7MvGWcSk98JyrVtveD8ZmZYyItSY7m2hcasqAFiKyOouV5vzyRe87/lEyzzBpF3bQQ4IDaQu+K9Hj5fKuU6rrOeOhsdnJc+VdDQLScHxvMoLZ9Vtt+oK9J4/tOLwr4CG8khDlBURcBY6gPcLo3dPU09SW+6ctX2cX4mkXx6O/0mmdTmacr/vu50KdRMleFeZYOWPAEhhMfywybTuzBiPVIZVP8WFCSKNMbfi1S9A9PdBqnebwwHhX3/hsEBt2BAgMBAAECggEABEI1P6nf6Zs7mJlyBDv+Pfl5rjL2cOqLy6TovvZVblMkCPpJyFuNIPDK2tK2i897ZaXfhPDBIKmllM2Hq6jZQKB110OAnTPDg0JxzMiIHPs32S1d/KilHjGff4Hjd4NXp1l1Dp8BUPOllorR2TYm2x6dcCGFw9lhTr8O03Qp4hjn84VjGIWADYCk83mgS4nRsnHkdiqYnWx1AjKlY51yEK6RcrDMi0Th2RXrrINoC35sVv+APt2rkoMGi52RwTEseA1KZGFrxjq61ReJif6p2VXEcvHeX6CWLx014LGk43z6Q28P6HgeEVEfIjyqCUea5Du/mYb/QsRSCosXLxBqwQKBgQD1+fdC9ZiMrVI+km7Nx2CKBn8rJrDmUh5SbXn2MYJdrUd8bYNnZkCgKMgxVXsvJrbmVOrby2txOiqudZkk5mD3E5O/QZWPWQLgRu8ueYNpobAX9NRgNfZ7rZD+81vh5MfZiXfuZOuzv29iZhU0oqyZ9y75eHkLdrerNkwYOe5aUQKBgQDLzapDi1NxkBgsj9iiO4KUa7jvD4JjRqFy4Zhj/jbQvlvM0F/uFp7sxVcHGx4r11C+6iCbhX4u+Zuu0HGjT4d+hNXmgGyxR8fIUVxOlOtDkVJa5sOBZK73/9/MBeKusdmJPRhalZQfMUJRWIoEVDMhfg3tW/rBj5RYAtP2dTVUMQKBgDs8yr52dRmT+BWXoFWwaWB0NhYHSFz/c8v4D4Ip5DJ5M5kUqquxJWksySGQa40sbqnD05fBQovPLU48hfgr/zghn9hUjBcsoZOvoZR4sRw0UztBvA+7jzOz1hKAOyWIulR6Vca0yUrNlJ6G5R56+sRNkiOETupi2dLCzcqb0PoxAoGAZyNHvTLvIZN4iGSrjz5qkM4LIwBIThFadxbv1fq6pt0O/BGf2o+cEdq0diYlGK64cEVwBwSBnSg4vzlBqRIAUejLjwEDAJyA4EE8Y5A9l04dzV7nJb5cRak6CrgXxay/mBJRFtaHxVlaZGxYPGSYE6UFS0+3EOmmevvDZQBf4qECgYEA0ZF6Vavz28+8wLO6SP3w8NmpHk7K9tGEvUfQ30SgDx4G7qPIgfPrbB4OP/E0qCfsIImi3sCPpjvUMQdVVZyPOIMuB+rV3ZOxkrzxEUOrpOpR48FZbL7RN90yRQsAsrp9e4iv8QwB3VxLe7X0TDqqnRyqrc/osGzuS2ZcHOKmCU8=
+-----END PRIVATE KEY-----`;
+
+  /*
+  The unwrapped signing key.
+  */
+  let signingKey;
+
+  const signButton = document.querySelector(".pkcs8 .sign-button");
+
   /*
   Convert a string into an ArrayBuffer
   from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
@@ -12,10 +23,6 @@
     }
     return buf;
   }
-
-  const pemEncodedKey = `-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDD0tPV/du2vftjvXj1t/gXTK39sNBVrOAEb/jKzXae+Xa0H+3LhZaQIQNMfACiBSgIfZUvEGb+7TqXWQpoLoFR/R7MvGWcSk98JyrVtveD8ZmZYyItSY7m2hcasqAFiKyOouV5vzyRe87/lEyzzBpF3bQQ4IDaQu+K9Hj5fKuU6rrOeOhsdnJc+VdDQLScHxvMoLZ9Vtt+oK9J4/tOLwr4CG8khDlBURcBY6gPcLo3dPU09SW+6ctX2cX4mkXx6O/0mmdTmacr/vu50KdRMleFeZYOWPAEhhMfywybTuzBiPVIZVP8WFCSKNMbfi1S9A9PdBqnebwwHhX3/hsEBt2BAgMBAAECggEABEI1P6nf6Zs7mJlyBDv+Pfl5rjL2cOqLy6TovvZVblMkCPpJyFuNIPDK2tK2i897ZaXfhPDBIKmllM2Hq6jZQKB110OAnTPDg0JxzMiIHPs32S1d/KilHjGff4Hjd4NXp1l1Dp8BUPOllorR2TYm2x6dcCGFw9lhTr8O03Qp4hjn84VjGIWADYCk83mgS4nRsnHkdiqYnWx1AjKlY51yEK6RcrDMi0Th2RXrrINoC35sVv+APt2rkoMGi52RwTEseA1KZGFrxjq61ReJif6p2VXEcvHeX6CWLx014LGk43z6Q28P6HgeEVEfIjyqCUea5Du/mYb/QsRSCosXLxBqwQKBgQD1+fdC9ZiMrVI+km7Nx2CKBn8rJrDmUh5SbXn2MYJdrUd8bYNnZkCgKMgxVXsvJrbmVOrby2txOiqudZkk5mD3E5O/QZWPWQLgRu8ueYNpobAX9NRgNfZ7rZD+81vh5MfZiXfuZOuzv29iZhU0oqyZ9y75eHkLdrerNkwYOe5aUQKBgQDLzapDi1NxkBgsj9iiO4KUa7jvD4JjRqFy4Zhj/jbQvlvM0F/uFp7sxVcHGx4r11C+6iCbhX4u+Zuu0HGjT4d+hNXmgGyxR8fIUVxOlOtDkVJa5sOBZK73/9/MBeKusdmJPRhalZQfMUJRWIoEVDMhfg3tW/rBj5RYAtP2dTVUMQKBgDs8yr52dRmT+BWXoFWwaWB0NhYHSFz/c8v4D4Ip5DJ5M5kUqquxJWksySGQa40sbqnD05fBQovPLU48hfgr/zghn9hUjBcsoZOvoZR4sRw0UztBvA+7jzOz1hKAOyWIulR6Vca0yUrNlJ6G5R56+sRNkiOETupi2dLCzcqb0PoxAoGAZyNHvTLvIZN4iGSrjz5qkM4LIwBIThFadxbv1fq6pt0O/BGf2o+cEdq0diYlGK64cEVwBwSBnSg4vzlBqRIAUejLjwEDAJyA4EE8Y5A9l04dzV7nJb5cRak6CrgXxay/mBJRFtaHxVlaZGxYPGSYE6UFS0+3EOmmevvDZQBf4qECgYEA0ZF6Vavz28+8wLO6SP3w8NmpHk7K9tGEvUfQ30SgDx4G7qPIgfPrbB4OP/E0qCfsIImi3sCPpjvUMQdVVZyPOIMuB+rV3ZOxkrzxEUOrpOpR48FZbL7RN90yRQsAsrp9e4iv8QwB3VxLe7X0TDqqnRyqrc/osGzuS2ZcHOKmCU8=
------END PRIVATE KEY-----`;
 
   /*
   Import a PEM encoded RSA private key, to use for RSA-PSS signing.
@@ -62,14 +69,14 @@ MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDD0tPV/du2vftjvXj1t/gXTK39sNBV
   Get the encoded message-to-sign, sign it and display a representation
   of the first part of it in the "signature" element.
   */
-  async function signMessage(privateKey) {
+  async function signMessage() {
     const encoded = getMessageEncoding();
     const signature = await window.crypto.subtle.sign(
       {
         name: "RSA-PSS",
         saltLength: 32,
       },
-      privateKey,
+      signingKey,
       encoded
     );
 
@@ -83,19 +90,28 @@ MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDD0tPV/du2vftjvXj1t/gXTK39sNBV
   }
 
   /*
+  Show and enable the sign button.
+  */
+  function enableSignButton() {
+    signButton.classList.add('fade-in');
+    signButton.addEventListener('animationend', () => {
+      signButton.classList.remove('fade-in');
+    });
+    signButton.removeAttribute("disabled");
+    signButton.classList.remove("hidden");
+  }
+
+  /*
   When the user clicks "Import Key"
   - import the key
   - enable the "Sign" button
-  - add a listener to "Sign" that uses the key.
   */
   const importKeyButton = document.querySelector(".pkcs8 .import-key-button");
   importKeyButton.addEventListener("click", async () => {
-    const privateKey = await importPrivateKey(pemEncodedKey);
-    const signButton = document.querySelector(".pkcs8 .sign-button");
-    signButton.removeAttribute("disabled");
-    signButton.addEventListener("click", () => {
-      signMessage(privateKey);
-    });
+    signingKey = await importPrivateKey(pemEncodedKey);
+    enableSignButton();
   });
+
+  signButton.addEventListener("click", signMessage);
 
 })();

--- a/web-crypto/import-key/pkcs8.js
+++ b/web-crypto/import-key/pkcs8.js
@@ -1,0 +1,101 @@
+(() => {
+
+  /*
+  Convert a string into an ArrayBuffer
+  from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
+  */
+  function str2ab(str) {
+    const buf = new ArrayBuffer(str.length);
+    const bufView = new Uint8Array(buf);
+    for (let i = 0, strLen = str.length; i < strLen; i++) {
+      bufView[i] = str.charCodeAt(i);
+    }
+    return buf;
+  }
+
+  const pemEncodedKey = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDD0tPV/du2vftjvXj1t/gXTK39sNBVrOAEb/jKzXae+Xa0H+3LhZaQIQNMfACiBSgIfZUvEGb+7TqXWQpoLoFR/R7MvGWcSk98JyrVtveD8ZmZYyItSY7m2hcasqAFiKyOouV5vzyRe87/lEyzzBpF3bQQ4IDaQu+K9Hj5fKuU6rrOeOhsdnJc+VdDQLScHxvMoLZ9Vtt+oK9J4/tOLwr4CG8khDlBURcBY6gPcLo3dPU09SW+6ctX2cX4mkXx6O/0mmdTmacr/vu50KdRMleFeZYOWPAEhhMfywybTuzBiPVIZVP8WFCSKNMbfi1S9A9PdBqnebwwHhX3/hsEBt2BAgMBAAECggEABEI1P6nf6Zs7mJlyBDv+Pfl5rjL2cOqLy6TovvZVblMkCPpJyFuNIPDK2tK2i897ZaXfhPDBIKmllM2Hq6jZQKB110OAnTPDg0JxzMiIHPs32S1d/KilHjGff4Hjd4NXp1l1Dp8BUPOllorR2TYm2x6dcCGFw9lhTr8O03Qp4hjn84VjGIWADYCk83mgS4nRsnHkdiqYnWx1AjKlY51yEK6RcrDMi0Th2RXrrINoC35sVv+APt2rkoMGi52RwTEseA1KZGFrxjq61ReJif6p2VXEcvHeX6CWLx014LGk43z6Q28P6HgeEVEfIjyqCUea5Du/mYb/QsRSCosXLxBqwQKBgQD1+fdC9ZiMrVI+km7Nx2CKBn8rJrDmUh5SbXn2MYJdrUd8bYNnZkCgKMgxVXsvJrbmVOrby2txOiqudZkk5mD3E5O/QZWPWQLgRu8ueYNpobAX9NRgNfZ7rZD+81vh5MfZiXfuZOuzv29iZhU0oqyZ9y75eHkLdrerNkwYOe5aUQKBgQDLzapDi1NxkBgsj9iiO4KUa7jvD4JjRqFy4Zhj/jbQvlvM0F/uFp7sxVcHGx4r11C+6iCbhX4u+Zuu0HGjT4d+hNXmgGyxR8fIUVxOlOtDkVJa5sOBZK73/9/MBeKusdmJPRhalZQfMUJRWIoEVDMhfg3tW/rBj5RYAtP2dTVUMQKBgDs8yr52dRmT+BWXoFWwaWB0NhYHSFz/c8v4D4Ip5DJ5M5kUqquxJWksySGQa40sbqnD05fBQovPLU48hfgr/zghn9hUjBcsoZOvoZR4sRw0UztBvA+7jzOz1hKAOyWIulR6Vca0yUrNlJ6G5R56+sRNkiOETupi2dLCzcqb0PoxAoGAZyNHvTLvIZN4iGSrjz5qkM4LIwBIThFadxbv1fq6pt0O/BGf2o+cEdq0diYlGK64cEVwBwSBnSg4vzlBqRIAUejLjwEDAJyA4EE8Y5A9l04dzV7nJb5cRak6CrgXxay/mBJRFtaHxVlaZGxYPGSYE6UFS0+3EOmmevvDZQBf4qECgYEA0ZF6Vavz28+8wLO6SP3w8NmpHk7K9tGEvUfQ30SgDx4G7qPIgfPrbB4OP/E0qCfsIImi3sCPpjvUMQdVVZyPOIMuB+rV3ZOxkrzxEUOrpOpR48FZbL7RN90yRQsAsrp9e4iv8QwB3VxLe7X0TDqqnRyqrc/osGzuS2ZcHOKmCU8=
+-----END PRIVATE KEY-----`;
+
+  /*
+  Import a PEM encoded RSA private key, to use for RSA-PSS signing.
+  Takes a string containing the PEM encoded key, and returns a Promise
+  that will resolve to a CryptoKey representing the private key.
+  */
+  function importPrivateKey(pem) {
+    // fetch the part of the PEM string between header and footer
+    const pemHeader = "-----BEGIN PRIVATE KEY-----";
+    const pemFooter = "-----END PRIVATE KEY-----";
+    const pemContents = pem.substring(pemHeader.length, pem.length - pemFooter.length);
+    // base64 decode the string to get the binary data
+    const binaryDerString = window.atob(pemContents);
+    // convert from a binary string to an ArrayBuffer
+    const binaryDer = str2ab(binaryDerString);
+
+    return window.crypto.subtle.importKey(
+      "pkcs8",
+      binaryDer,
+      {
+        name: "RSA-PSS",
+        // Consider using a 4096-bit key for systems that require long-term security
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign"]
+    );
+  }
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for the sign operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".pkcs8 #message");
+    const message = messageBox.value;
+    const enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message-to-sign, sign it and display a representation
+  of the first part of it in the "signature" element.
+  */
+  async function signMessage(privateKey) {
+    const encoded = getMessageEncoding();
+    const signature = await window.crypto.subtle.sign(
+      {
+        name: "RSA-PSS",
+        saltLength: 32,
+      },
+      privateKey,
+      encoded
+    );
+
+    const signatureValue = document.querySelector(".pkcs8 .signature-value");
+    signatureValue.classList.add('fade-in');
+    signatureValue.addEventListener('animationend', () => {
+      signatureValue.classList.remove('fade-in');
+    });
+    const buffer = new Uint8Array(signature, 0, 5);
+    signatureValue.textContent = `${buffer}...[${signature.byteLength} bytes total]`;
+  }
+
+  /*
+  When the user clicks "Import Key"
+  - import the key
+  - enable the "Sign" button
+  - add a listener to "Sign" that uses the key.
+  */
+  const importKeyButton = document.querySelector(".pkcs8 .import-key-button");
+  importKeyButton.addEventListener("click", async () => {
+    const privateKey = await importPrivateKey(pemEncodedKey);
+    const signButton = document.querySelector(".pkcs8 .sign-button");
+    signButton.removeAttribute("disabled");
+    signButton.addEventListener("click", () => {
+      signMessage(privateKey);
+    });
+  });
+
+})();

--- a/web-crypto/import-key/pkcs8.js
+++ b/web-crypto/import-key/pkcs8.js
@@ -52,7 +52,7 @@ MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDD0tPV/du2vftjvXj1t/gXTK39sNBV
   in a form we can use for the sign operation.
   */
   function getMessageEncoding() {
-    const messageBox = document.querySelector(".pkcs8 #message");
+    const messageBox = document.querySelector("#pkcs8-message");
     const message = messageBox.value;
     const enc = new TextEncoder();
     return enc.encode(message);

--- a/web-crypto/import-key/raw.js
+++ b/web-crypto/import-key/raw.js
@@ -22,7 +22,7 @@
   in a form we can use for the encrypt operation.
   */
   function getMessageEncoding() {
-    const messageBox = document.querySelector(".raw #message");
+    const messageBox = document.querySelector("#raw-message");
     const message = messageBox.value;
     const enc = new TextEncoder();
     return enc.encode(message);

--- a/web-crypto/import-key/raw.js
+++ b/web-crypto/import-key/raw.js
@@ -1,0 +1,73 @@
+(() => {
+
+  const rawKey = window.crypto.getRandomValues(new Uint8Array(16));
+
+  /*
+  Import an AES secret key from an ArrayBuffer containing the raw bytes.
+  Takes an ArrayBuffer string containing the bytes, and returns a Promise
+  that will resolve to a CryptoKey representing the secret key.
+  */
+  function importSecretKey(rawKey) {
+    return window.crypto.subtle.importKey(
+      "raw",
+      rawKey,
+      "AES-GCM",
+      true,
+      ["encrypt", "decrypt"]
+    );
+  }
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for the encrypt operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".raw #message");
+    const message = messageBox.value;
+    const enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message, encrypt it and display a representation
+  of the ciphertext in the "Ciphertext" element.
+  */
+  async function encryptMessage(key) {
+    const encoded = getMessageEncoding();
+    // iv will be needed for decryption
+    const iv = window.crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await window.crypto.subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv: iv
+      },
+      key,
+      encoded
+    );
+
+    const buffer = new Uint8Array(ciphertext, 0, 5);
+    const ciphertextValue = document.querySelector(".raw .ciphertext-value");
+    ciphertextValue.classList.add('fade-in');
+    ciphertextValue.addEventListener('animationend', () => {
+      ciphertextValue.classList.remove('fade-in');
+    });
+    ciphertextValue.textContent = `${buffer}...[${ciphertext.byteLength} bytes total]`;
+  }
+
+  /*
+  When the user clicks "Import Key"
+  - import the key
+  - enable the "Encrypt" button
+  - add a listener to "Encrypt" that uses the key.
+  */
+  const importKeyButton = document.querySelector(".raw .import-key-button");
+  importKeyButton.addEventListener("click", async () => {
+    const secretKey = await importSecretKey(rawKey);
+    const encryptButton = document.querySelector(".raw .encrypt-button");
+    encryptButton.removeAttribute("disabled");
+    encryptButton.addEventListener("click", () => {
+      encryptMessage(secretKey);
+    });
+  });
+
+})();

--- a/web-crypto/import-key/raw.js
+++ b/web-crypto/import-key/raw.js
@@ -3,6 +3,13 @@
   const rawKey = window.crypto.getRandomValues(new Uint8Array(16));
 
   /*
+  The imported secret key.
+  */
+  let secretKey;
+
+  const encryptButton = document.querySelector(".raw .encrypt-button");
+
+  /*
   Import an AES secret key from an ArrayBuffer containing the raw bytes.
   Takes an ArrayBuffer string containing the bytes, and returns a Promise
   that will resolve to a CryptoKey representing the secret key.
@@ -32,7 +39,7 @@
   Get the encoded message, encrypt it and display a representation
   of the ciphertext in the "Ciphertext" element.
   */
-  async function encryptMessage(key) {
+  async function encryptMessage() {
     const encoded = getMessageEncoding();
     // iv will be needed for decryption
     const iv = window.crypto.getRandomValues(new Uint8Array(12));
@@ -41,7 +48,7 @@
         name: "AES-GCM",
         iv: iv
       },
-      key,
+      secretKey,
       encoded
     );
 
@@ -54,20 +61,29 @@
     ciphertextValue.textContent = `${buffer}...[${ciphertext.byteLength} bytes total]`;
   }
 
+    /*
+    Show and enable the encrypt button.
+    */
+    function enableEncryptButton() {
+      encryptButton.classList.add('fade-in');
+      encryptButton.addEventListener('animationend', () => {
+        encryptButton.classList.remove('fade-in');
+      });
+      encryptButton.removeAttribute("disabled");
+      encryptButton.classList.remove("hidden");
+    }
+
   /*
   When the user clicks "Import Key"
   - import the key
   - enable the "Encrypt" button
-  - add a listener to "Encrypt" that uses the key.
   */
   const importKeyButton = document.querySelector(".raw .import-key-button");
   importKeyButton.addEventListener("click", async () => {
-    const secretKey = await importSecretKey(rawKey);
-    const encryptButton = document.querySelector(".raw .encrypt-button");
-    encryptButton.removeAttribute("disabled");
-    encryptButton.addEventListener("click", () => {
-      encryptMessage(secretKey);
-    });
+    secretKey = await importSecretKey(rawKey);
+    enableEncryptButton();
   });
+
+  encryptButton.addEventListener("click", encryptMessage);
 
 })();

--- a/web-crypto/import-key/spki.js
+++ b/web-crypto/import-key/spki.js
@@ -1,5 +1,16 @@
 (() => {
 
+  const pemEncodedKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy3Xo3U13dc+xojwQYWoJLCbOQ5fOVY8LlnqcJm1W1BFtxIhOAJWohiHuIRMctv7dzx47TLlmARSKvTRjd0dF92jx/xY20Lz+DXp8YL5yUWAFgA3XkO3LSJgEOex10NB8jfkmgSb7QIudTVvbbUDfd5fwIBmCtaCwWx7NyeWWDb7A9cFxj7EjRdrDaK3ux/ToMLHFXVLqSL341TkCf4ZQoz96RFPUGPPLOfvN0x66CM1PQCkdhzjE6U5XGE964ZkkYUPPsy6Dcie4obhW4vDjgUmLzv0z7UD010RLIneUgDE2FqBfY/C+uWigNPBPkkQ+Bv/UigS6dHqTCVeD5wgyBQIDAQAB
+-----END PUBLIC KEY-----`;
+
+  /*
+  The unwrapped signing key.
+  */
+  let encryptionKey;
+
+  const encryptButton = document.querySelector(".spki .encrypt-button");
+
   /*
   Convert a string into an ArrayBuffer
   from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
@@ -12,10 +23,6 @@
     }
     return buf;
   }
-
-  const pemEncodedKey = `-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy3Xo3U13dc+xojwQYWoJLCbOQ5fOVY8LlnqcJm1W1BFtxIhOAJWohiHuIRMctv7dzx47TLlmARSKvTRjd0dF92jx/xY20Lz+DXp8YL5yUWAFgA3XkO3LSJgEOex10NB8jfkmgSb7QIudTVvbbUDfd5fwIBmCtaCwWx7NyeWWDb7A9cFxj7EjRdrDaK3ux/ToMLHFXVLqSL341TkCf4ZQoz96RFPUGPPLOfvN0x66CM1PQCkdhzjE6U5XGE964ZkkYUPPsy6Dcie4obhW4vDjgUmLzv0z7UD010RLIneUgDE2FqBfY/C+uWigNPBPkkQ+Bv/UigS6dHqTCVeD5wgyBQIDAQAB
------END PUBLIC KEY-----`;
 
   /*
   Import a PEM encoded RSA public key, to use for RSA-OAEP encryption.
@@ -59,13 +66,13 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy3Xo3U13dc+xojwQYWoJLCbOQ5fOVY8Llnqc
   Get the encoded message, encrypt it and display a representation
   of the ciphertext in the "Ciphertext" element.
   */
-  async function encryptMessage(key) {
+  async function encryptMessage() {
     const encoded = getMessageEncoding();
     const ciphertext = await window.crypto.subtle.encrypt(
       {
         name: "RSA-OAEP"
       },
-      key,
+      encryptionKey,
       encoded
     );
 
@@ -79,19 +86,28 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy3Xo3U13dc+xojwQYWoJLCbOQ5fOVY8Llnqc
   }
 
   /*
+  Show and enable the encrypt button.
+  */
+  function enableEncryptButton() {
+    encryptButton.classList.add('fade-in');
+    encryptButton.addEventListener('animationend', () => {
+      encryptButton.classList.remove('fade-in');
+    });
+    encryptButton.removeAttribute("disabled");
+    encryptButton.classList.remove("hidden");
+  }
+
+  /*
   When the user clicks "Import Key"
   - import the key
   - enable the "Encrypt" button
-  - add a listener to "Encrypt" that uses the key.
   */
   const importKeyButton = document.querySelector(".spki .import-key-button");
   importKeyButton.addEventListener("click", async () => {
-    const publicKey = await importPublicKey(pemEncodedKey);
-    const encryptButton = document.querySelector(".spki .encrypt-button");
-    encryptButton.removeAttribute("disabled");
-    encryptButton.addEventListener("click", () => {
-      encryptMessage(publicKey);
-    });
+    encryptionKey = await importPublicKey(pemEncodedKey);
+    enableEncryptButton();
   });
+
+  encryptButton.addEventListener("click", encryptMessage);
 
 })();

--- a/web-crypto/import-key/spki.js
+++ b/web-crypto/import-key/spki.js
@@ -1,0 +1,97 @@
+(() => {
+
+  /*
+  Convert a string into an ArrayBuffer
+  from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
+  */
+  function str2ab(str) {
+    const buf = new ArrayBuffer(str.length);
+    const bufView = new Uint8Array(buf);
+    for (let i = 0, strLen = str.length; i < strLen; i++) {
+      bufView[i] = str.charCodeAt(i);
+    }
+    return buf;
+  }
+
+  const pemEncodedKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy3Xo3U13dc+xojwQYWoJLCbOQ5fOVY8LlnqcJm1W1BFtxIhOAJWohiHuIRMctv7dzx47TLlmARSKvTRjd0dF92jx/xY20Lz+DXp8YL5yUWAFgA3XkO3LSJgEOex10NB8jfkmgSb7QIudTVvbbUDfd5fwIBmCtaCwWx7NyeWWDb7A9cFxj7EjRdrDaK3ux/ToMLHFXVLqSL341TkCf4ZQoz96RFPUGPPLOfvN0x66CM1PQCkdhzjE6U5XGE964ZkkYUPPsy6Dcie4obhW4vDjgUmLzv0z7UD010RLIneUgDE2FqBfY/C+uWigNPBPkkQ+Bv/UigS6dHqTCVeD5wgyBQIDAQAB
+-----END PUBLIC KEY-----`;
+
+  /*
+  Import a PEM encoded RSA public key, to use for RSA-OAEP encryption.
+  Takes a string containing the PEM encoded key, and returns a Promise
+  that will resolve to a CryptoKey representing the public key.
+  */
+  function importPublicKey(pem) {
+    // fetch the part of the PEM string between header and footer
+    const pemHeader = "-----BEGIN PUBLIC KEY-----";
+    const pemFooter = "-----END PUBLIC KEY-----";
+    const pemContents = pem.substring(pemHeader.length, pem.length - pemFooter.length);
+    // base64 decode the string to get the binary data
+    const binaryDerString = window.atob(pemContents);
+    // convert from a binary string to an ArrayBuffer
+    const binaryDer = str2ab(binaryDerString);
+
+    return window.crypto.subtle.importKey(
+      "spki",
+      binaryDer,
+      {
+        name: "RSA-OAEP",
+        hash: "SHA-256"
+      },
+      true,
+      ["encrypt"]
+    );
+  }
+
+  /*
+  Fetch the contents of the "message" textbox, and encode it
+  in a form we can use for the encrypt operation.
+  */
+  function getMessageEncoding() {
+    const messageBox = document.querySelector(".spki #message");
+    const message = messageBox.value;
+    const enc = new TextEncoder();
+    return enc.encode(message);
+  }
+
+  /*
+  Get the encoded message, encrypt it and display a representation
+  of the ciphertext in the "Ciphertext" element.
+  */
+  async function encryptMessage(key) {
+    const encoded = getMessageEncoding();
+    const ciphertext = await window.crypto.subtle.encrypt(
+      {
+        name: "RSA-OAEP"
+      },
+      key,
+      encoded
+    );
+
+    const buffer = new Uint8Array(ciphertext, 0, 5);
+    const ciphertextValue = document.querySelector(".spki .ciphertext-value");
+    ciphertextValue.classList.add('fade-in');
+    ciphertextValue.addEventListener('animationend', () => {
+      ciphertextValue.classList.remove('fade-in');
+    });
+    ciphertextValue.textContent = `${buffer}...[${ciphertext.byteLength} bytes total]`;
+  }
+
+  /*
+  When the user clicks "Import Key"
+  - import the key
+  - enable the "Encrypt" button
+  - add a listener to "Encrypt" that uses the key.
+  */
+  const importKeyButton = document.querySelector(".spki .import-key-button");
+  importKeyButton.addEventListener("click", async () => {
+    const publicKey = await importPublicKey(pemEncodedKey);
+    const encryptButton = document.querySelector(".spki .encrypt-button");
+    encryptButton.removeAttribute("disabled");
+    encryptButton.addEventListener("click", () => {
+      encryptMessage(publicKey);
+    });
+  });
+
+})();

--- a/web-crypto/import-key/spki.js
+++ b/web-crypto/import-key/spki.js
@@ -49,7 +49,7 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy3Xo3U13dc+xojwQYWoJLCbOQ5fOVY8Llnqc
   in a form we can use for the encrypt operation.
   */
   function getMessageEncoding() {
-    const messageBox = document.querySelector(".spki #message");
+    const messageBox = document.querySelector("#spki-message");
     const message = messageBox.value;
     const enc = new TextEncoder();
     return enc.encode(message);

--- a/web-crypto/import-key/style.css
+++ b/web-crypto/import-key/style.css
@@ -39,6 +39,15 @@ h1 {
     font-family: monospace;
 }
 
+.sign-button, .encrypt-button {
+    background-color: green;
+    color: white;
+}
+
+.hidden {
+    display: none;
+}
+
 /* Whole page grid */
 main {
     display: grid;

--- a/web-crypto/import-key/style.css
+++ b/web-crypto/import-key/style.css
@@ -1,0 +1,103 @@
+/* General setup */
+
+* {
+    box-sizing: border-box;
+}
+
+html,body {
+    font-family: sans-serif;
+    line-height: 1.2rem;
+}
+
+/* Layout and styles */
+
+h1 {
+    color: green;
+    margin-left: .5rem;
+}
+
+.description, .import-key {
+    margin: 0 .5rem;
+}
+
+.description > p {
+    margin-top: 0;
+}
+
+.import-key {
+    box-shadow: -1px 2px 5px gray;
+    padding: .2rem .5rem;
+    margin-bottom: 2rem;
+}
+
+.import-key-controls > * {
+    margin: .5rem 0;
+}
+
+.ciphertext-value, .signature-value {
+    padding-left: .5rem;
+    font-family: monospace;
+}
+
+/* Whole page grid */
+main {
+    display: grid;
+    grid-template-columns: 36rem 1fr;
+    grid-template-rows: 4rem 1fr;
+}
+
+h1 {
+    grid-column: 1/2;
+    grid-row: 1;
+}
+
+.examples {
+    grid-column: 1;
+    grid-row: 2;
+}
+
+.description {
+    grid-column: 2;
+    grid-row: 2;
+}
+
+/* encrypt-decrypt controls grid */
+.import-key-controls {
+    display: grid;
+    grid-template-columns: 1fr 8rem;
+    grid-template-rows: 1fr 1fr;
+}
+
+.message-control {
+    grid-column-start: 1;
+    grid-row-start: 1;
+}
+
+.ciphertext, .signature {
+    grid-column-start: 1;
+    grid-row-start: 2;
+}
+
+.import-button {
+    grid-column-start: 2;
+    grid-row-start: 1;
+}
+
+.encrypt-button, .sign-button {
+    grid-column-start: 2;
+    grid-row-start: 2;
+}
+
+/* Animate output display */
+.fade-in {
+    animation: fadein .5s;
+}
+
+@keyframes fadein {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
Here are some examples for the [`importKey()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey) function.

They're a lot like the others, but this is organised by import format rather than by algorithm.

There's a fair bit of annoying byte-shuffling going on with the PKSC#8 and SPKI ones - it seems like you're supposed to use `TextDecoder` rather than the example I copied from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String, but I could not get that to work, perhaps because the string does actually contain just binary data and not UTF-8?