### PR TITLE
Remove erroneous call to `DataTransfer.clearData()`

### DIFF
--- a/drag-and-drop/File-drag.html
+++ b/drag-and-drop/File-drag.html
@@ -67,9 +67,6 @@
       if (ev.dataTransfer.items) {
         // Use DataTransferItemList interface to remove the drag data
         ev.dataTransfer.items.clear();
-      } else {
-        // Use DataTransfer interface to remove the drag data
-        ev.dataTransfer.clearData();
       }
     }
   </script>

--- a/drag-and-drop/copy-move-DataTransfer.html
+++ b/drag-and-drop/copy-move-DataTransfer.html
@@ -64,8 +64,6 @@ function dragend_handler(ev) {
   console.log("dragEnd");
   // Restore source's border
   ev.target.style.border = "solid black";
-  // Remove all of the drag data
-  ev.dataTransfer.clearData();
 }
 </script>
 </head>


### PR DESCRIPTION
Documentation indicates `DataTransfer.clearData()` may only be used in
the handler for the `dragstart` event, https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/clearData

Otherwise, it results in the following error:

`NoModificationAllowedError: Modifications are not allowed for this document`

As described in https://bugzilla.mozilla.org/show_bug.cgi?id=1267942

Fix the examples to avoid browser errors causing confusion when learning
Drag and Drop.