### PR TITLE
Remove unused variable declarations in encrypt-decrypt example

### DIFF
--- a/web-crypto/encrypt-decrypt/aes-cbc.js
+++ b/web-crypto/encrypt-decrypt/aes-cbc.js
@@ -48,7 +48,6 @@
   Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {
-    let encoded = getMessageEncoding();
     let decrypted = await window.crypto.subtle.decrypt(
       {
         name: "AES-CBC",

--- a/web-crypto/encrypt-decrypt/aes-cbc.js
+++ b/web-crypto/encrypt-decrypt/aes-cbc.js
@@ -44,7 +44,7 @@
   }
 
   /*
-  Fetch the encoded message and decrypt it.
+  Fetch the ciphertext and decrypt it.
   Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {

--- a/web-crypto/encrypt-decrypt/aes-ctr.js
+++ b/web-crypto/encrypt-decrypt/aes-ctr.js
@@ -45,7 +45,7 @@
   }
 
   /*
-  Fetch the encoded message and decrypt it.
+  Fetch the ciphertext and decrypt it.
   Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {

--- a/web-crypto/encrypt-decrypt/aes-ctr.js
+++ b/web-crypto/encrypt-decrypt/aes-ctr.js
@@ -49,7 +49,6 @@
   Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {
-    let encoded = getMessageEncoding();
     let decrypted = await window.crypto.subtle.decrypt(
       {
         name: "AES-CTR",

--- a/web-crypto/encrypt-decrypt/aes-gcm.js
+++ b/web-crypto/encrypt-decrypt/aes-gcm.js
@@ -48,7 +48,6 @@
   Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {
-    let encoded = getMessageEncoding();
     let decrypted = await window.crypto.subtle.decrypt(
       {
         name: "AES-GCM",

--- a/web-crypto/encrypt-decrypt/aes-gcm.js
+++ b/web-crypto/encrypt-decrypt/aes-gcm.js
@@ -44,7 +44,7 @@
   }
 
   /*
-  Fetch the encoded message and decrypt it.
+  Fetch the ciphertext and decrypt it.
   Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {

--- a/web-crypto/encrypt-decrypt/rsa-oaep.js
+++ b/web-crypto/encrypt-decrypt/rsa-oaep.js
@@ -40,7 +40,7 @@
   }
 
   /*
-  Fetch the encoded message and decrypt it.
+  Fetch the ciphertext and decrypt it.
   Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {

--- a/web-crypto/encrypt-decrypt/rsa-oaep.js
+++ b/web-crypto/encrypt-decrypt/rsa-oaep.js
@@ -44,7 +44,6 @@
   Write the decrypted message into the "Decrypted" box.
   */
   async function decryptMessage(key) {
-    let encoded = getMessageEncoding();
     let decrypted = await window.crypto.subtle.decrypt(
       {
         name: "RSA-OAEP"


### PR DESCRIPTION
Removing these unused variables might improve readability and reduce confusion :)