### PR TITLE
Add Fullscreen API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 * The "drag-and-drop" directory is for examples and demos of the [HTML Drag and Drop](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API) standard.
 
+* The "fullscreen-api" directory is for examples and demos of the [Fullscreen API](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API). Run the [example live](http://mdn.github.io/dom-examples/fullscreen-api/).
+
 * The "insert-adjacent" directory contains simple demos for [insertAdjacentElement](http://mdn.github.io/dom-examples/insert-adjacent/insertAdjacentElement.html) and [insertAdjacentText](http://mdn.github.io/dom-examples/insert-adjacent/insertAdjacentText.html).
 
 * The "matchmedia" directory contains a simple demo to test matchMedia functionality. See [Window.matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) for more details. [Run the demo live](http://mdn.github.io/dom-examples/matchmedia/).

--- a/fullscreen-api/README.md
+++ b/fullscreen-api/README.md
@@ -1,6 +1,6 @@
 
 # Fullscreen API example
 
-The example toggles the video in and out of fullscreen mode on the press of ENTER key.
+This example allows you to toggle the video in and out of fullscreen mode by pressing the <kbd>Enter</kbd> key.
 
 [See the example live](https://mdn.github.io/dom-examples/fullscreen-api/).

--- a/fullscreen-api/README.md
+++ b/fullscreen-api/README.md
@@ -1,0 +1,6 @@
+
+# Fullscreen API example
+
+The example toggles the video in and out of fullscreen mode on the press of ENTER key.
+
+[See the example live](https://mdn.github.io/dom-examples/fullscreen-api/).

--- a/fullscreen-api/index.html
+++ b/fullscreen-api/index.html
@@ -9,9 +9,9 @@
 
 <body>
   <div id="contents">
-    <p>A quick example for the use of the <code>Fullscreen</code> API. Press <code>ENTER</code> key to toggle Full screen.</p>
+    <p>A quick example to demonstrate usage of the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API">Fullscreen API</a>. Press <kbd>Enter</kbd> to toggle fullscreen mode.</p>
 
-    <video src="assets/bigbuckbunny.mp4" id="video" muted autoplay width="300"></video>
+    <video src="assets/bigbuckbunny.mp4" id="video" controls width="480"></video>
 
     <div id="credits"><a href="https://peach.blender.org/download/">Video by Blender</a>;
       <a href="https://peach.blender.org/about/">licensed CC-BY 3.0</a></div>

--- a/fullscreen-api/index.html
+++ b/fullscreen-api/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+
+<head>
+  <title>Fullscreen API Example</title>
+  <script src="main.js"></script>
+  <link href="main.css" rel="stylesheet">
+</head>
+
+<body>
+  <div id="contents">
+    <p>A quick example for the use of the <code>Fullscreen</code> API. Press <code>ENTER</code> key to toggle Full screen.</p>
+
+    <video src="assets/bigbuckbunny.mp4" id="video" muted autoplay width="300"></video>
+
+    <div id="credits"><a href="https://peach.blender.org/download/">Video by Blender</a>;
+      <a href="https://peach.blender.org/about/">licensed CC-BY 3.0</a></div>
+  </div>
+</body>
+
+</html>

--- a/fullscreen-api/main.css
+++ b/fullscreen-api/main.css
@@ -1,0 +1,9 @@
+#contents {
+	width: 600px;
+	font: 14px "Open Sans", sans-serif;
+}
+
+#credits {
+	padding: 0 0 10px 0;
+	font: italic 10px "Open Sans", sans-serif;
+}

--- a/fullscreen-api/main.css
+++ b/fullscreen-api/main.css
@@ -1,9 +1,8 @@
-#contents {
-	width: 600px;
-	font: 14px "Open Sans", sans-serif;
-}
-
 #credits {
 	padding: 0 0 10px 0;
-	font: italic 10px "Open Sans", sans-serif;
+	font: italic 12px "Open Sans", sans-serif;
+}
+
+#video {
+	max-width: 100%;
 }

--- a/fullscreen-api/main.js
+++ b/fullscreen-api/main.js
@@ -1,0 +1,28 @@
+window.addEventListener("load", startup, false);
+
+function startup() {
+  // Get the reference to video
+  const video = document.getElementById("video");
+
+  // On pressing ENTER call toggleFullScreen method
+  document.addEventListener("keypress", function(e) {
+    if (e.keyCode === 13) {
+      toggleFullScreen(video);
+    }
+  }, false);
+}
+
+function toggleFullScreen(video) {
+  if (!document.fullscreenElement) {
+    // If the document is not in full screen mode
+    // make the video full screen
+    video.requestFullscreen();
+  } else {
+    // Otherwise exit the full screen
+    if (document.exitFullscreen) {
+      document.exitFullscreen();
+    }
+  }
+}
+
+

--- a/fullscreen-api/main.js
+++ b/fullscreen-api/main.js
@@ -6,7 +6,7 @@ function startup() {
 
   // On pressing ENTER call toggleFullScreen method
   document.addEventListener("keypress", function(e) {
-    if (e.keyCode === 13) {
+    if (e.key === 'Enter') {
       toggleFullScreen(video);
     }
   }, false);


### PR DESCRIPTION
The PR adds an example for [Full screen API](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API) since [the existing one](https://media.prod.mdn.mozit.cloud/samples/domref/fullscreen.html) is broken.

See https://github.com/mdn/sprints/issues/3828

__Thoughts:__ I have tried to keep the example similar to the example code shown in the API doc. So the example listens to `ENTER` key and nothing more. Can add frills like buttons and event log if that enhances the example's utility.

Another thing to consider is would the key binding work when used with`{{EmbedGHLiveSample()}}` macro?
