### PR TITLE
Fix image smoothing properties in canvas zoom demo

### DIFF
--- a/canvas/pixel-manipulation/image-smoothing.js
+++ b/canvas/pixel-manipulation/image-smoothing.js
@@ -11,13 +11,16 @@ function draw(img) {
   ctx.drawImage(img, 0, 0);
 
 	var smoothedZoomCtx = document.getElementById('smoothed-zoom').getContext('2d');
-	smoothedZoomCtx.imageSmoothingEnabled = this.checked;
-	smoothedZoomCtx.mozImageSmoothingEnabled = this.checked;
-	smoothedZoomCtx.webkitImageSmoothingEnabled = this.checked;
-	smoothedZoomCtx.msImageSmoothingEnabled = this.checked;
+	smoothedZoomCtx.imageSmoothingEnabled = true;
+	smoothedZoomCtx.mozImageSmoothingEnabled = true;
+	smoothedZoomCtx.webkitImageSmoothingEnabled = true;
+	smoothedZoomCtx.msImageSmoothingEnabled = true;
 
 	var pixelatedZoomCtx = document.getElementById('pixelated-zoom').getContext('2d');
-
+	pixelatedZoomCtx.imageSmoothingEnabled = false;
+	pixelatedZoomCtx.mozImageSmoothingEnabled = false;
+	pixelatedZoomCtx.webkitImageSmoothingEnabled = false;
+	pixelatedZoomCtx.msImageSmoothingEnabled = false;
 
   var zoom = function(ctx, x, y) {
     ctx.drawImage(canvas,


### PR DESCRIPTION
This example demonstrates the use of canvas elements to zoom in on a part of an image.  This code is used on MDN [here](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas#Zooming_and_anti-aliasing).

This PR fixes a bug in the code whereby the "smoothed" canvas actually has image smoothing disabled, while the "pixelated" canvas has image smoothing enabled by default.