### PR TITLE
Fix resize observer examples

### DIFF
--- a/resize-observer/resize-observer-border-radius.html
+++ b/resize-observer/resize-observer-border-radius.html
@@ -28,9 +28,16 @@
     <script>
       const resizeObserver = new ResizeObserver(entries => {
         for (let entry of entries) {
-          if(entry.contentBoxSize) {
-            entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize.inlineSize/10) +
-                                                            (entry.contentBoxSize.blockSize/10)) + 'px';
+          if (entry.contentBoxSize) {
+            // The standard makes contentBoxSize an array...
+            if (entry.contentBoxSize[0]) {
+              entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize[0].inlineSize/10) +
+                                                              (entry.contentBoxSize[0].blockSize/10)) + 'px';
+            } else {
+              // ...but old versions of Firefox treat it as a single item
+              entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize.inlineSize/10) +
+                                                              (entry.contentBoxSize.blockSize/10)) + 'px';
+            }
           } else {
             entry.target.style.borderRadius = Math.min(100, (entry.contentRect.width/10) +
                                                             (entry.contentRect.height/10)) + 'px';

--- a/resize-observer/resize-observer-text.html
+++ b/resize-observer/resize-observer-text.html
@@ -80,15 +80,16 @@
         const resizeObserver = new ResizeObserver(entries => {
           for (let entry of entries) {
             if(entry.contentBoxSize) {
-              // Checking for chrome as using a non-standard array
+              // The standard makes contentBoxSize an array...
               if (entry.contentBoxSize[0]) {
                 h1Elem.style.fontSize = Math.max(1.5, entry.contentBoxSize[0].inlineSize/200) + 'rem';
                 pElem.style.fontSize = Math.max(1, entry.contentBoxSize[0].inlineSize/600) + 'rem';
               } else {
+                // ...but old versions of Firefox treat it as a single item
                 h1Elem.style.fontSize = Math.max(1.5, entry.contentBoxSize.inlineSize/200) + 'rem';
                 pElem.style.fontSize = Math.max(1, entry.contentBoxSize.inlineSize/600) + 'rem';
               }
-              
+
             } else {
               h1Elem.style.fontSize = Math.max(1.5, entry.contentRect.width/200) + 'rem';
               pElem.style.fontSize = Math.max(1, entry.contentRect.width/600) + 'rem';


### PR DESCRIPTION
In Firefox, https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/contentBoxSize used to be a single entry, while the standard (and Chrome) implemented it as an array of entries.

See also https://github.com/mdn/content/pull/3180.

Firefox recently fixed this: https://bugzilla.mozilla.org/show_bug.cgi?id=1689645 .

In dom-examples, one of the examples only worked with the old-Firefox implementation, and the other incorrectly claimed that Chrome's version was non-standard.

This PR is supposed to fix both those issues.

