### PR TITLE
Fix pick coordinates relative to the image

### DIFF
--- a/canvas/pixel-manipulation/color-picker.js
+++ b/canvas/pixel-manipulation/color-picker.js
@@ -12,8 +12,9 @@ var selectedColor = document.getElementById('selected-color');
 
 
 function pick(event, destination) {
-  var x = event.layerX;
-  var y = event.layerY;
+  var rect = event.target.getBoundingClientRect();
+  var x = event.layerX - rect.left;
+  var y = event.layerY - rect.top;
   var pixel = ctx.getImageData(x, y, 1, 1);
   var data = pixel.data;
 


### PR DESCRIPTION
Current code uses absolute mouse coordinates instead of relative to the canvas, which in turn makes the actual hovered/selected color inaccurate (there's an x/y offset that reads pixel further towards top/left direction)
This diff hasn't been tested in the exact tutorial context, but seems to fix the bug and work fine in a simpler, similar unit test (which had the exact same issue)