### PR TITLE
Fix stream simple-pump example.

### DIFF
--- a/streams/simple-pump/index.html
+++ b/streams/simple-pump/index.html
@@ -10,7 +10,7 @@
 <h1>Simple Stream Pump</h1>
 <p>The left tortoise is the original, the right one is created using a custom stream.</p>
 <img src="tortoise.png" width="150" height="84" alt="Tortoise Original">
-<img src="tortoise.png" width="150" height="84" alt="Tortoise Copy" id="target">
+<img src="." width="150" height="84" alt="Tortoise Copy" id="target">
 <script>
   const image = document.getElementById('target');
 


### PR DESCRIPTION
The simple-pump example wasn't convincing because when you
view source, it showed that both images' src attribute
were tortoise.jpg. By inspection, you couldn't tell that
the stream was modifying the second image's src.

I fixed this by changing the second image's src to ".".

Tested by running it in Firefox and seeing that the second
image still shows a tortoise.