### PR TITLE
Streams/simple-writer: fixed block character in the output.

### DIFF
--- a/streams/simple-writer/index.html
+++ b/streams/simple-writer/index.html
@@ -46,7 +46,7 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-8");
+const decoder = new TextDecoder("utf-16");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({


### PR DESCRIPTION
There are unwanted block characters in the output:
![screenshot](https://i.imgur.com/4ZQnmHK.png)

With `utf-16` encoding for the decoder, it fixes the issue:
```
const decoder = new TextDecoder("utf-16");
```