### PR TITLE
Fix broken picture-in-picture example credit links

### DIFF
--- a/picture-in-picture/index.html
+++ b/picture-in-picture/index.html
@@ -11,8 +11,8 @@
 
 			<video src="assets/bigbuckbunny.mp4" id="video" muted autoplay width="300"></video>
 
-      <div id="credits"><a href="https://peach.blender.org/download/">Video by Blender</a>;
-      <a href="https://peach.blender.org/about/">licensed CC-BY 3.0</a></div>
+      <div id="credits"><a href="https://peach.blender.org/download/" target="_blank">Video by Blender</a>;
+      <a href="https://peach.blender.org/about/" target="_blank">licensed CC-BY 3.0</a></div>
 
       <div id="controlbar">
 				<p class="no-picture-in-picture">


### PR DESCRIPTION
### Why

https://developer.mozilla.org/en-US/docs/Web/API/Picture-in-Picture_API

Clicking on the links here will break the iframe. Adding `target="_blank"` allows them to open in a new  tab of the parent frame, which is more desirable.