### PR TITLE
streams/simple-writer: remove invalid parameter

### DIFF
--- a/streams/simple-writer/index.html
+++ b/streams/simple-writer/index.html
@@ -19,7 +19,7 @@ function sendMessage(message, writableStream) {
   // defaultWriter is of type WritableStreamDefaultWriter
   const defaultWriter = writableStream.getWriter();
   const encoder = new TextEncoder();
-  const encoded = encoder.encode(message, { stream: true });
+  const encoded = encoder.encode(message);
   encoded.forEach((chunk) => {
     defaultWriter.ready
       .then(() => {


### PR DESCRIPTION
There is a `{ stream: true }` does not exists on the `TextEncoder.encode` parameter list.