### PR TITLE
WebGL sample8: Drop “autoplay”; add “playsInline”

### DIFF
--- a/webgl-examples/tutorial/sample8/webgl-demo.js
+++ b/webgl-examples/tutorial/sample8/webgl-demo.js
@@ -125,7 +125,7 @@ function setupVideo(url) {
   var playing = false;
   var timeupdate = false;
 
-  video.autoplay = true;
+  video.playsInline = true;
   video.muted = true;
   video.loop = true;
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/13775. See also https://github.com/mdn/content/pull/19178.

Tested in Safari mobile on iOS 15.5, tested in Firefox mobile and Chrome mobile on Android, and tested in Safari, Chrome, and Firefox on desktop macOS — and found that the demo works as expected in all browsers without the `autoplay` attribute needing to be specified, and works in Safari mobile on iOS 15.5 as long as `playsInline` is specified.

See https://stackoverflow.com/a/73244068/441757 for live running code.