### PR TITLE
Removed Unnecessary bindBuffer call

### DIFF
--- a/webgl-examples/tutorial/sample2/webgl-demo.js
+++ b/webgl-examples/tutorial/sample2/webgl-demo.js
@@ -55,10 +55,10 @@ function main() {
 
   // Here's where we call the routine that builds all the
   // objects we'll be drawing.
-  const buffers = initBuffers(gl);
+  initBuffers(gl);
 
   // Draw the scene
-  drawScene(gl, programInfo, buffers);
+  drawScene(gl, programInfo);
 }
 
 //
@@ -94,16 +94,12 @@ function initBuffers(gl) {
   gl.bufferData(gl.ARRAY_BUFFER,
                 new Float32Array(positions),
                 gl.STATIC_DRAW);
-
-  return {
-    position: positionBuffer,
-  };
 }
 
 //
 // Draw the scene.
 //
-function drawScene(gl, programInfo, buffers) {
+function drawScene(gl, programInfo) {
   gl.clearColor(0.0, 0.0, 0.0, 1.0);  // Clear to black, fully opaque
   gl.clearDepth(1.0);                 // Clear everything
   gl.enable(gl.DEPTH_TEST);           // Enable depth testing
@@ -153,7 +149,6 @@ function drawScene(gl, programInfo, buffers) {
     const normalize = false;
     const stride = 0;
     const offset = 0;
-    gl.bindBuffer(gl.ARRAY_BUFFER, buffers.position);
     gl.vertexAttribPointer(
         programInfo.attribLocations.vertexPosition,
         numComponents,


### PR DESCRIPTION
bindBuffer has already been called once at line 79 
```js
gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
```
so calling it again with 
```js
gl.bindBuffer(gl.ARRAY_BUFFER, buffers.position);
```
is superfluous.


The demo still works after the edit.
<img width="1478" alt="image" src="https://user-images.githubusercontent.com/56601823/184546265-7b08aea4-1500-42df-9656-127210cb20a2.png">
