### PR TITLE
Unbreak color picker example, fix closing table tag

### DIFF
--- a/canvas/pixel-manipulation/color-picker.html
+++ b/canvas/pixel-manipulation/color-picker.html
@@ -29,7 +29,7 @@
 				<td align="center" class="color-cell" id="selected-color"></td>
 			</tr>
 		</tbody>
-	<table>
+	</table>
 	<script src="color-picker.js"></script>
   </body>
 </html>

--- a/canvas/pixel-manipulation/color-picker.js
+++ b/canvas/pixel-manipulation/color-picker.js
@@ -1,6 +1,6 @@
 const img = new Image();
 img.crossOrigin = 'anonymous';
-img.src = '/assets/rhino.jpg';
+img.src = './assets/rhino.jpg';
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 img.addEventListener('load', () => {


### PR DESCRIPTION
I managed to break the color-picker example by fiddling with https://github.com/mdn/dom-examples/pull/100. This should fix it, and also fixes the closing tag for the table, mentioned at https://github.com/mdn/content/issues/20060#issuecomment-1229437836.

You can see the example working again at https://wbamberg.github.io/dom-examples/canvas/pixel-manipulation/color-picker.