### PR TITLE
11591 OffscreenCanvas worker thread example

### DIFF
--- a/web-workers/offscreen-canvas-worker/README.md
+++ b/web-workers/offscreen-canvas-worker/README.md
@@ -1,0 +1,11 @@
+# offscreen-canvas-worker
+
+This example shows how to use an `OffscreenCanvasContext` with a web worked.
+[View this demo live](https://mdn.github.io/dom-examples/web-workers/offscreen-canvas-worker/).
+
+To run this code locally you'll need to serve it. If you have [node](https://nodejs.org/) installed, navigate to the folder containing the code and run `lite-server`:
+
+```bash
+cd /web-workers/offscreen-canvas-worker
+npx lite-server
+```

--- a/web-workers/offscreen-canvas-worker/README.md
+++ b/web-workers/offscreen-canvas-worker/README.md
@@ -6,6 +6,6 @@ This example shows how to use an `OffscreenCanvasContext` with a web worked.
 To run this code locally you'll need to serve it. If you have [node](https://nodejs.org/) installed, navigate to the folder containing the code and run `lite-server`:
 
 ```bash
-cd /web-workers/offscreen-canvas-worker
+cd web-workers/offscreen-canvas-worker
 npx lite-server
 ```

--- a/web-workers/offscreen-canvas-worker/index.html
+++ b/web-workers/offscreen-canvas-worker/index.html
@@ -7,93 +7,104 @@
   </head>
   <body>
     <header>
-      <div id="support-div">Your browser does not support OffscreenCanvas</div>
+      <h1>OffscreenCanvas and worker threads</h1>
+      <p>This example has two canvases with incrementing counters.</p>
+
+      <p>
+        Canvas A is being drawn to on the main thread. Canvas B uses an
+        OffscreenCanvas so that we can draw to it in a worker thread. The
+        purpose of this example is to show how a worker thread can keep the rest
+        of our UI responsive.
+      </p>
+
+      <p>
+        The button below each canvas creates <b>blocking work</b> on either the
+        main thread (Canvas A) or a worker thread (Canvas B). When a thread is
+        blocked, the canvas' counter in that thread is blocked.
+      </p>
     </header>
 
     <main>
-      <h2>Simulate a heavy process:</h2>
-
-      <button id="main-button" onclick="slowMainThread()">Canvas A</button>
-      <button id="worker-button" onclick="slowdownWorker()">Canvas B</button>
-
-      <div class="ui-example">
-        <button>Hover example</button><button>Hover example</button
-        ><button>Hover example</button><button>Hover example</button>
-      </div>
-
-      <h2>Counters:</h2>
-      <div class="visualisation">
+      <div class="canvases">
         <div>
           <span class="canvas-title">Canvas A</span>
-          <canvas id="canvas main" width="400" height="400"></canvas>
+          <canvas id="canvas main" width="200" height="200"></canvas>
+          <div>
+            <button id="main-button" onclick="slowMainThread()">
+              Main thread
+            </button>
+          </div>
         </div>
         <div>
           <span class="canvas-title">Canvas B</span>
-          <canvas id="canvas worker" width="400" height="400"></canvas>
+          <canvas id="canvas worker" width="200" height="200"></canvas>
+
+          <div>
+            <button id="worker-button" onclick="slowdownWorker()">
+              Worker thread
+            </button>
+          </div>
         </div>
+      </div>
+      <div id="canvas-description">
+        <p>
+          <b>When the main thread is blocked</b>, all UI elements are frozen.
+          The hover effect on all buttons is affected:
+        </p>
+        <button>Example button</button>
+        <p>
+          <b>When the worker thread is blocked</b>, the main thread is free to
+          do work such as the element hover effects and animations. Blocking the
+          worker thread will still prevent Canvas B's counter from being
+          updated, but the UI stays responsive while this happens.
+        </p>
       </div>
     </main>
 
     <script>
-      document
-        .querySelector("#support-div")
-        .classList.add(
-          "OffscreenCanvas" in window ? "supported" : "not-supported"
-        );
-
-      document.querySelector("#support-div").innerHTML =
-        "OffscreenCanvas" in window
-          ? "Your browser supports the OffscreenCanvas API "
-          : "Your browser does not support OffscreenCanvas";
-
       const requestAnimationFrame = window.requestAnimationFrame;
 
-      // Init Canvas A (running on the current page)
       const canvasA = document.getElementById("canvas main");
-      const indicator = document.getElementById("indicator");
-      const ctxA = canvasA.getContext("2d");
+      const canvasB = document.getElementById("canvas worker");
 
+      const ctxA = canvasA.getContext("2d");
       const canvasWidth = ctxA.width;
       const canvasHeight = ctxA.height;
 
-      // Setup the counter for Canvas A
+      // Create a counter for Canvas A
       let counter = 0;
       setInterval(function () {
         redrawCanvasA();
         counter++;
       }, 100);
 
-      // Redraw Canvas A text
+      // Redraw Canvas A counter
       function redrawCanvasA() {
         ctxA.clearRect(0, 0, canvasA.width, canvasA.height);
-        ctxA.font = "16px Verdana";
+        ctxA.font = "24px Verdana";
         ctxA.textAlign = "center";
-        ctxA.fillText(
-          "Counter: " + counter,
-          canvasA.width / 2,
-          canvasA.height / 2
-        );
+        ctxA.fillText(counter, canvasA.width / 2, canvasA.height / 2);
       }
 
-      // Using the OffscreenCanvas API and starting the worker
-      var cWorker = document
-        .getElementById("canvas worker")
-        .transferControlToOffscreen();
-      var worker = new Worker("worker.js");
-      worker.postMessage({ canvas: cWorker }, [cWorker]);
-
-      // Fibonacci function to add some delay to the thread
+      // This function creates heavy (blocking) work on a thread
       function fibonacci(num) {
         if (num <= 1) return 1;
         return fibonacci(num - 1) + fibonacci(num - 2);
       }
 
+      // Call our Fibonacci function on the main thread
       function slowMainThread() {
         fibonacci(42);
       }
 
-      // Initiate the slowing down of Canvas B
-      // By sending a message to the worker
+      // Set up a worker thread to render Canvas B
+      const worker = new Worker("worker.js");
+
+      // Use the OffscreenCanvas API and send to the worker thread
+      const canvasWorker = canvasB.transferControlToOffscreen();
+      worker.postMessage({ canvas: canvasWorker }, [canvasWorker]);
+
+      // A 'slowDown' message we can catch in the worker to start heavy work
       function slowdownWorker() {
         worker.postMessage("slowDown");
       }

--- a/web-workers/offscreen-canvas-worker/index.html
+++ b/web-workers/offscreen-canvas-worker/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
     <title>OffscreenCanvas API</title>
+
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -12,15 +14,20 @@
 
       <p>
         Canvas A is being drawn to on the main thread. Canvas B uses an
-        OffscreenCanvas so that we can draw to it in a worker thread. The
-        purpose of this example is to show how a worker thread can keep the rest
-        of our UI responsive.
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas"
+          ><code>OffscreenCanvas</code></a
+        >
+        so that we can draw to it in a worker thread. The purpose of this
+        example is to show how a worker thread can keep the rest of our UI
+        responsive.
       </p>
 
       <p>
         The button below each canvas creates <b>blocking work</b> on either the
         main thread (Canvas A) or a worker thread (Canvas B). When a thread is
-        blocked, the canvas' counter in that thread is blocked.
+        blocked, incrementing the related counter from that thread is also
+        blocked.
       </p>
     </header>
 
@@ -31,7 +38,7 @@
           <canvas id="canvas main" width="200" height="200"></canvas>
           <div>
             <button id="main-button" onclick="slowMainThread()">
-              Main thread
+              Block main thread
             </button>
           </div>
         </div>
@@ -41,7 +48,7 @@
 
           <div>
             <button id="worker-button" onclick="slowdownWorker()">
-              Worker thread
+              Block worker thread
             </button>
           </div>
         </div>
@@ -49,7 +56,7 @@
       <div id="canvas-description">
         <p>
           <b>When the main thread is blocked</b>, all UI elements are frozen.
-          The hover effect on all buttons is affected:
+          The hover effect on buttons is affected like this one:
         </p>
         <button>Example button</button>
         <p>
@@ -59,6 +66,13 @@
           updated, but the UI stays responsive while this happens.
         </p>
       </div>
+
+      <footer>
+        <p>
+          This demo is based on an example by
+          <a href="https://glitch.com/@PicchiKevin">Kevin Picchi</a>.
+        </p>
+      </footer>
     </main>
 
     <script>

--- a/web-workers/offscreen-canvas-worker/index.html
+++ b/web-workers/offscreen-canvas-worker/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OffscreenCanvas API</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <div id="support-div">Your browser does not support OffscreenCanvas</div>
+    </header>
+
+    <main>
+      <h2>Simulate a heavy process:</h2>
+
+      <button onclick="fibonacci(40)">Canvas A</button>
+      <button onclick="slowdownWorker()">Canvas B</button>
+
+      <div>
+        <button>Test button</button><button>Test button</button
+        ><button>Test button</button><button>Test button</button
+        ><button>Test button</button><button>Test button</button>
+      </div>
+
+      <h2>Visualization:</h2>
+      <div class="visualisation">
+        <div>
+          <span class="canvas-title">Canvas A</span>
+          <canvas id="canvas main" width="400" height="400"></canvas>
+        </div>
+        <div>
+          <span class="canvas-title">Canvas B</span>
+          <canvas id="canvas worker" width="400" height="400"></canvas>
+        </div>
+      </div>
+    </main>
+
+    <script>
+      document
+        .querySelector("#support-div")
+        .classList.add(
+          "OffscreenCanvas" in window ? "supported" : "not-supported"
+        );
+
+      document.querySelector("#support-div").innerHTML =
+        "OffscreenCanvas" in window
+          ? "Your browser supports the OffscreenCanvas API "
+          : "Your browser does not support OffscreenCanvas";
+
+      var requestAnimationFrame =
+        window.requestAnimationFrame ||
+        window.mozRequestAnimationFrame ||
+        window.webkitRequestAnimationFrame ||
+        window.msRequestAnimationFrame;
+
+      // Init Canvas A (running on the current page)
+      var canvasA = document.getElementById("canvas main");
+      var ctxA = canvasA.getContext("2d");
+
+      var canvasWidth = ctxA.width;
+      var canvasHeight = ctxA.height;
+
+      // Redraw Canvas A text
+      function redrawCanvasA() {
+        ctxA.clearRect(0, 0, canvasWidth, canvasHeight);
+
+        // color in the background
+        ctxA.fillStyle = "#EEEEEE";
+        ctxA.fillRect(0, 0, canvasWidth, canvasHeight);
+
+        // draw the circle
+        ctxA.beginPath();
+
+        var radius = 25 + 20 * Math.abs(Math.cos(angle));
+        ctxA.arc(70, 70, radius, 0, Math.PI * 2, false);
+        ctxA.closePath();
+
+        // color in the circle
+        ctxA.fillStyle = "#006699";
+        ctxA.fill();
+
+        angle += Math.PI / 64;
+
+        requestAnimationFrame(drawCircle);
+      }
+
+      // Using the OffscreenCanvas API and starting the worker
+      var cWorker = document
+        .getElementById("canvas worker")
+        .transferControlToOffscreen();
+      var worker = new Worker("worker.js");
+      worker.postMessage({ canvas: cWorker }, [cWorker]);
+
+      // Fibonacci function to add some delay to the thread
+      function fibonacci(num) {
+        if (num <= 1) return 1;
+        return fibonacci(num - 1) + fibonacci(num - 2);
+      }
+
+      // Initiate the slowing down of Canvas B
+      // By sending a message to the worker
+      function slowdownWorker() {
+        worker.postMessage("slowDown");
+      }
+    </script>
+  </body>
+</html>

--- a/web-workers/offscreen-canvas-worker/index.html
+++ b/web-workers/offscreen-canvas-worker/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OffscreenCanvas API</title>
     <link rel="stylesheet" href="style.css" />
@@ -14,16 +13,15 @@
     <main>
       <h2>Simulate a heavy process:</h2>
 
-      <button onclick="fibonacci(40)">Canvas A</button>
-      <button onclick="slowdownWorker()">Canvas B</button>
+      <button id="main-button" onclick="slowMainThread()">Canvas A</button>
+      <button id="worker-button" onclick="slowdownWorker()">Canvas B</button>
 
-      <div>
-        <button>Test button</button><button>Test button</button
-        ><button>Test button</button><button>Test button</button
-        ><button>Test button</button><button>Test button</button>
+      <div class="ui-example">
+        <button>Hover example</button><button>Hover example</button
+        ><button>Hover example</button><button>Hover example</button>
       </div>
 
-      <h2>Visualization:</h2>
+      <h2>Counters:</h2>
       <div class="visualisation">
         <div>
           <span class="canvas-title">Canvas A</span>
@@ -48,41 +46,33 @@
           ? "Your browser supports the OffscreenCanvas API "
           : "Your browser does not support OffscreenCanvas";
 
-      var requestAnimationFrame =
-        window.requestAnimationFrame ||
-        window.mozRequestAnimationFrame ||
-        window.webkitRequestAnimationFrame ||
-        window.msRequestAnimationFrame;
+      const requestAnimationFrame = window.requestAnimationFrame;
 
       // Init Canvas A (running on the current page)
-      var canvasA = document.getElementById("canvas main");
-      var ctxA = canvasA.getContext("2d");
+      const canvasA = document.getElementById("canvas main");
+      const indicator = document.getElementById("indicator");
+      const ctxA = canvasA.getContext("2d");
 
-      var canvasWidth = ctxA.width;
-      var canvasHeight = ctxA.height;
+      const canvasWidth = ctxA.width;
+      const canvasHeight = ctxA.height;
+
+      // Setup the counter for Canvas A
+      let counter = 0;
+      setInterval(function () {
+        redrawCanvasA();
+        counter++;
+      }, 100);
 
       // Redraw Canvas A text
       function redrawCanvasA() {
-        ctxA.clearRect(0, 0, canvasWidth, canvasHeight);
-
-        // color in the background
-        ctxA.fillStyle = "#EEEEEE";
-        ctxA.fillRect(0, 0, canvasWidth, canvasHeight);
-
-        // draw the circle
-        ctxA.beginPath();
-
-        var radius = 25 + 20 * Math.abs(Math.cos(angle));
-        ctxA.arc(70, 70, radius, 0, Math.PI * 2, false);
-        ctxA.closePath();
-
-        // color in the circle
-        ctxA.fillStyle = "#006699";
-        ctxA.fill();
-
-        angle += Math.PI / 64;
-
-        requestAnimationFrame(drawCircle);
+        ctxA.clearRect(0, 0, canvasA.width, canvasA.height);
+        ctxA.font = "16px Verdana";
+        ctxA.textAlign = "center";
+        ctxA.fillText(
+          "Counter: " + counter,
+          canvasA.width / 2,
+          canvasA.height / 2
+        );
       }
 
       // Using the OffscreenCanvas API and starting the worker
@@ -96,6 +86,10 @@
       function fibonacci(num) {
         if (num <= 1) return 1;
         return fibonacci(num - 1) + fibonacci(num - 2);
+      }
+
+      function slowMainThread() {
+        fibonacci(42);
       }
 
       // Initiate the slowing down of Canvas B

--- a/web-workers/offscreen-canvas-worker/index.html
+++ b/web-workers/offscreen-canvas-worker/index.html
@@ -42,7 +42,7 @@
       <div class="canvases">
         <div>
           <span class="canvas-title">Canvas A</span>
-          <canvas id="canvas main" width="200" height="200"></canvas>
+          <canvas id="main" width="200" height="200"></canvas>
           <div>
             <button id="main-button" onclick="slowMainThread()">
               Block main thread
@@ -51,7 +51,7 @@
         </div>
         <div>
           <span class="canvas-title">Canvas B</span>
-          <canvas id="canvas worker" width="200" height="200"></canvas>
+          <canvas id="worker" width="200" height="200"></canvas>
 
           <div>
             <button id="worker-button" onclick="slowdownWorker()">
@@ -83,10 +83,8 @@
     </main>
 
     <script>
-      const requestAnimationFrame = window.requestAnimationFrame;
-
-      const canvasA = document.getElementById("canvas main");
-      const canvasB = document.getElementById("canvas worker");
+      const canvasA = document.getElementById("main");
+      const canvasB = document.getElementById("worker");
 
       const ctxA = canvasA.getContext("2d");
       const canvasWidth = ctxA.width;
@@ -94,7 +92,7 @@
 
       // Create a counter for Canvas A
       let counter = 0;
-      setInterval(function () {
+      setInterval(() => {
         redrawCanvasA();
         counter++;
       }, 100);
@@ -109,7 +107,9 @@
 
       // This function creates heavy (blocking) work on a thread
       function fibonacci(num) {
-        if (num <= 1) return 1;
+        if (num <= 1) {
+          return 1;
+        }
         return fibonacci(num - 1) + fibonacci(num - 2);
       }
 

--- a/web-workers/offscreen-canvas-worker/index.html
+++ b/web-workers/offscreen-canvas-worker/index.html
@@ -10,6 +10,13 @@
   <body>
     <header>
       <h1>OffscreenCanvas and worker threads</h1>
+      <p>
+        <b>Note:</b> your browser must support
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas"
+          ><code>OffscreenCanvas</code></a
+        >.
+      </p>
       <p>This example has two canvases with incrementing counters.</p>
 
       <p>
@@ -55,15 +62,15 @@
       </div>
       <div id="canvas-description">
         <p>
-          <b>When the main thread is blocked</b>, all UI elements are frozen.
-          The hover effect on buttons is affected like this one:
+          <b>When the main thread is blocked</b>, all UI elements are frozen.<br />
+          The hover effect on buttons is also blocked:
         </p>
         <button>Example button</button>
         <p>
           <b>When the worker thread is blocked</b>, the main thread is free to
           do work such as the element hover effects and animations. Blocking the
           worker thread will still prevent Canvas B's counter from being
-          updated, but the UI stays responsive while this happens.
+          updated, but the rest of the UI stays responsive while this is true.
         </p>
       </div>
 

--- a/web-workers/offscreen-canvas-worker/style.css
+++ b/web-workers/offscreen-canvas-worker/style.css
@@ -59,7 +59,13 @@ button {
 }
 
 button:hover {
-  background: lightblue;
+  background: rgb(235, 86, 41);
+}
+
+.ui-example button:hover {
+      transition: transform 0.5s;
+  transform: scale(1.3, 1.3);
+
 }
 
 .visualisation {

--- a/web-workers/offscreen-canvas-worker/style.css
+++ b/web-workers/offscreen-canvas-worker/style.css
@@ -4,7 +4,8 @@ body {
   margin: 2rem;
 }
 
-main, footer {
+main,
+footer {
   display: flex;
   align-content: left;
   justify-content: left;
@@ -22,7 +23,8 @@ header {
   max-width: 50%;
 }
 
-button, canvas {
+button,
+canvas {
   border-radius: 10px;
 }
 
@@ -50,7 +52,7 @@ canvas:hover {
   color: black;
 }
 
-#canvas-description  {
+#canvas-description {
   max-width: 50%;
   text-align: left;
 }
@@ -71,7 +73,7 @@ canvas:hover {
   margin-bottom: 1rem;
 }
 
-.canvases  {
+.canvases {
   text-align: center;
   display: flex;
   flex-wrap: wrap;

--- a/web-workers/offscreen-canvas-worker/style.css
+++ b/web-workers/offscreen-canvas-worker/style.css
@@ -1,80 +1,85 @@
 html,
 body {
-  margin: 0;
-  padding: 0;
-  background: whitesmoke;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: sans-serif;
+  margin: 2rem;
 }
 
-#support-div {
-  font-size: 2em;
-  text-align: center;
+main {
+  display: flex;
+  align-content: left;
+  justify-content: left;
+  flex-direction: column;
+  flex-wrap: wrap;
+  text-align: left;
+  margin-bottom: 4rem;
+}
+
+header {
+  font-size: 1em;
   min-height: 1em;
   line-height: 1.5em;
+  margin: 1rem;
+  max-width: 50%;
 }
 
-.supported {
-  background: lightgreen;
-}
-
-.not-supported {
-  background: crimson;
+button, canvas {
+  border-radius: 10px;
 }
 
 canvas {
-  border: 1px solid black;
-  background: #fff;
+  border: 2px solid black;
+  margin: 2rem;
+}
+
+button {
+  background: #797676;
+  padding: 10px;
+  margin: 10px;
+  border: 0;
+  color: white;
+  font-size: 1em;
+  max-width: 150px;
+}
+
+/* Hover effect for buttons */
+button:hover,
+canvas:hover {
+  background: rgb(242, 134, 102);
+  transition: transform 0.5s;
+  transform: scale(1.3, 1.3);
+  color: black;
+}
+
+#canvas-description  {
+  max-width: 50%;
+  text-align: center;
+}
+
+#canvas-description>p {
+  text-align: left;
+}
+
+.ui-example {
+  margin: 2rem;
+}
+
+.ui-example button:hover {
+  transition: transform 0.5s;
+  transform: scale(1.3, 1.3);
 }
 
 .canvas-title {
   display: block;
-  text-align: center;
   font-size: 1.4em;
   font-weight: bold;
-  margin-bottom: 20px;
+  margin-bottom: 1rem;
 }
 
-main,
-footer {
-  display: flex;
-  align-content: center;
-  justify-content: center;
-  flex-direction: column;
-  flex-wrap: wrap;
+.canvases  {
   text-align: center;
-}
-
-ul {
-  list-style: none;
-}
-
-button {
-  background: #acacac;
-  padding: 10px;
-  margin: 10px;
-  border: 0;
-  border-radius: 10px;
-  color: white;
-  font-size: 1em;
-}
-
-button:hover {
-  background: rgb(235, 86, 41);
-}
-
-.ui-example button:hover {
-      transition: transform 0.5s;
-  transform: scale(1.3, 1.3);
-
-}
-
-.visualisation {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  align-content: center;
-}
-
-.visualisation>div {
-  margin: 5px;
+  justify-content: left;
+  align-content: left;
+  padding: 2rem;
 }

--- a/web-workers/offscreen-canvas-worker/style.css
+++ b/web-workers/offscreen-canvas-worker/style.css
@@ -52,10 +52,6 @@ canvas:hover {
 
 #canvas-description  {
   max-width: 50%;
-  text-align: center;
-}
-
-#canvas-description>p {
   text-align: left;
 }
 

--- a/web-workers/offscreen-canvas-worker/style.css
+++ b/web-workers/offscreen-canvas-worker/style.css
@@ -1,0 +1,74 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: whitesmoke;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+#support-div {
+  font-size: 2em;
+  text-align: center;
+  min-height: 1em;
+  line-height: 1.5em;
+}
+
+.supported {
+  background: lightgreen;
+}
+
+.not-supported {
+  background: crimson;
+}
+
+canvas {
+  border: 1px solid black;
+  background: #fff;
+}
+
+.canvas-title {
+  display: block;
+  text-align: center;
+  font-size: 1.4em;
+  font-weight: bold;
+  margin-bottom: 20px;
+}
+
+main,
+footer {
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  flex-direction: column;
+  flex-wrap: wrap;
+  text-align: center;
+}
+
+ul {
+  list-style: none;
+}
+
+button {
+  background: #acacac;
+  padding: 10px;
+  margin: 10px;
+  border: 0;
+  border-radius: 10px;
+  color: white;
+  font-size: 1em;
+}
+
+button:hover {
+  background: lightblue;
+}
+
+.visualisation {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-content: center;
+}
+
+.visualisation>div {
+  margin: 5px;
+}

--- a/web-workers/offscreen-canvas-worker/style.css
+++ b/web-workers/offscreen-canvas-worker/style.css
@@ -4,7 +4,7 @@ body {
   margin: 2rem;
 }
 
-main {
+main, footer {
   display: flex;
   align-content: left;
   justify-content: left;

--- a/web-workers/offscreen-canvas-worker/worker.js
+++ b/web-workers/offscreen-canvas-worker/worker.js
@@ -4,13 +4,10 @@ let ctxWorker = null;
 // Waiting to receive the OffScreenCanvas
 self.onmessage = function (e) {
   if (e.data === "slowDown") {
-    // canvasB.style.border = "2px solid red";
     fibonacci(42);
   } else {
     canvasB = e.data.canvas;
-
     ctxWorker = canvasB.getContext("2d");
-    // canvasB.style.border = "1px solid black";
     startCounting();
   }
 };

--- a/web-workers/offscreen-canvas-worker/worker.js
+++ b/web-workers/offscreen-canvas-worker/worker.js
@@ -2,11 +2,11 @@ let canvasB = null;
 let ctxWorker = null;
 
 // Waiting to receive the OffScreenCanvas
-self.onmessage = function (e) {
-  if (e.data === "slowDown") {
+self.onmessage = (event) => {
+  if (event.data === "slowDown") {
     fibonacci(42);
   } else {
-    canvasB = e.data.canvas;
+    canvasB = event.data.canvas;
     ctxWorker = canvasB.getContext("2d");
     startCounting();
   }
@@ -14,14 +14,16 @@ self.onmessage = function (e) {
 
 // Fibonacci function to add some delay to the thread
 function fibonacci(num) {
-  if (num <= 1) return 1;
+  if (num <= 1) {
+    return 1;
+  }
   return fibonacci(num - 1) + fibonacci(num - 2);
 }
 
 // Start the counter for Canvas B
 let counter = 0;
 function startCounting() {
-  setInterval(function () {
+  setInterval(() => {
     redrawCanvasB();
     counter++;
   }, 100);

--- a/web-workers/offscreen-canvas-worker/worker.js
+++ b/web-workers/offscreen-canvas-worker/worker.js
@@ -4,7 +4,7 @@ var ctxWorker = null;
 // Waiting to receive the OffScreenCanvas
 self.onmessage = function (e) {
   if (typeof e.data == "string") {
-    for (let i = 0; i < 2000000000; i++) {}
+    fibonacci(42);
   } else {
     canvasB = e.data.canvas;
     ctxWorker = canvasB.getContext("2d");
@@ -12,6 +12,12 @@ self.onmessage = function (e) {
     startCounting();
   }
 };
+
+// Fibonacci function to add some delay to the thread
+function fibonacci(num) {
+  if (num <= 1) return 1;
+  return fibonacci(num - 1) + fibonacci(num - 2);
+}
 
 // Start the counter for Canvas B
 var counter = 0;
@@ -22,13 +28,13 @@ function startCounting() {
   }, 100);
 }
 
-// Redraw Canvas A text
+// Redraw Canvas B text
 function redrawCanvasB() {
   ctxWorker.clearRect(0, 0, canvasB.width, canvasB.height);
   ctxWorker.font = "16px Verdana";
   ctxWorker.textAlign = "center";
   ctxWorker.fillText(
-    "Counting: " + counter,
+    "Counter: " + counter,
     canvasB.width / 2,
     canvasB.height / 2
   );

--- a/web-workers/offscreen-canvas-worker/worker.js
+++ b/web-workers/offscreen-canvas-worker/worker.js
@@ -1,0 +1,35 @@
+var canvasB = null;
+var ctxWorker = null;
+
+// Waiting to receive the OffScreenCanvas
+self.onmessage = function (e) {
+  if (typeof e.data == "string") {
+    for (let i = 0; i < 2000000000; i++) {}
+  } else {
+    canvasB = e.data.canvas;
+    ctxWorker = canvasB.getContext("2d");
+
+    startCounting();
+  }
+};
+
+// Start the counter for Canvas B
+var counter = 0;
+function startCounting() {
+  setInterval(function () {
+    redrawCanvasB();
+    counter++;
+  }, 100);
+}
+
+// Redraw Canvas A text
+function redrawCanvasB() {
+  ctxWorker.clearRect(0, 0, canvasB.width, canvasB.height);
+  ctxWorker.font = "16px Verdana";
+  ctxWorker.textAlign = "center";
+  ctxWorker.fillText(
+    "Counting: " + counter,
+    canvasB.width / 2,
+    canvasB.height / 2
+  );
+}

--- a/web-workers/offscreen-canvas-worker/worker.js
+++ b/web-workers/offscreen-canvas-worker/worker.js
@@ -1,14 +1,16 @@
-var canvasB = null;
-var ctxWorker = null;
+let canvasB = null;
+let ctxWorker = null;
 
 // Waiting to receive the OffScreenCanvas
 self.onmessage = function (e) {
-  if (typeof e.data == "string") {
+  if (e.data === "slowDown") {
+    // canvasB.style.border = "2px solid red";
     fibonacci(42);
   } else {
     canvasB = e.data.canvas;
-    ctxWorker = canvasB.getContext("2d");
 
+    ctxWorker = canvasB.getContext("2d");
+    // canvasB.style.border = "1px solid black";
     startCounting();
   }
 };
@@ -20,7 +22,7 @@ function fibonacci(num) {
 }
 
 // Start the counter for Canvas B
-var counter = 0;
+let counter = 0;
 function startCounting() {
   setInterval(function () {
     redrawCanvasB();
@@ -31,11 +33,7 @@ function startCounting() {
 // Redraw Canvas B text
 function redrawCanvasB() {
   ctxWorker.clearRect(0, 0, canvasB.width, canvasB.height);
-  ctxWorker.font = "16px Verdana";
+  ctxWorker.font = "24px Verdana";
   ctxWorker.textAlign = "center";
-  ctxWorker.fillText(
-    "Counter: " + counter,
-    canvasB.width / 2,
-    canvasB.height / 2
-  );
+  ctxWorker.fillText(counter, canvasB.width / 2, canvasB.height / 2);
 }


### PR DESCRIPTION
This PR adds an example for using `OffscreenCanvas` in a worker thread. This is one of the main use cases of this feature. Background info here: https://wiki.whatwg.org/wiki/OffscreenCanvas#Use_Case_Description, e.g.:

* "need to be able to render WebGL from a worker, transfer the rendered image to the main thread without making any copy of it"
* "need to be able to render WebGL entirely asynchronously from a worker"
* "need to be able to layout  and render text from a worker using CanvasRenderingContext2D and display those results on the main thread."

__Notes:__
* Parent task: https://github.com/mdn/content/issues/11591