### PR TITLE
fix(importPublicKey): extract pemContents

### DIFF
--- a/web-crypto/import-key/spki.js
+++ b/web-crypto/import-key/spki.js
@@ -33,7 +33,7 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy3Xo3U13dc+xojwQYWoJLCbOQ5fOVY8Llnqc
     // fetch the part of the PEM string between header and footer
     const pemHeader = "-----BEGIN PUBLIC KEY-----";
     const pemFooter = "-----END PUBLIC KEY-----";
-    const pemContents = pem.substring(pemHeader.length, pem.length - pemFooter.length);
+    const pemContents = pem.substring(pemHeader.length, pem.length - pemFooter.length - 1).trim();
     // base64 decode the string to get the binary data
     const binaryDerString = window.atob(pemContents);
     // convert from a binary string to an ArrayBuffer


### PR DESCRIPTION
Import a PEM encoded RSA private key function importPrivateKey(pem) did not properly extract the pemContents.

Corrected length -1 and added trim() to remove newline/whitespace if present.

related https://github.com/mdn/content/pull/21540