### PR TITLE
CSS painting examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 * The "channel-messaging-multimessage" directory contains another channel messaging demo, showing how multiple messages can be sent between browsing contexts. See [Channel Messaging API](https://developer.mozilla.org/en-US/docs/Web/API/Channel_Messaging_API) for more details. [Run the demo live](https://mdn.github.io/dom-examples/channel-messaging-multimessage/).
 
+* The "css-painting" directory contains examples demonstrating the [CSS Painting API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Painting_API). See the [examples live](https://mdn.github.io/dom-examples/css-painting).
+
 * The "drag-and-drop" directory is for examples and demos of the [HTML Drag and Drop](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API) standard.
 
 * The "fullscreen-api" directory is for examples and demos of the [Fullscreen API](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API). Run the [example live](https://mdn.github.io/dom-examples/fullscreen-api/).

--- a/css-painting/custom-properties/boxbg.js
+++ b/css-painting/custom-properties/boxbg.js
@@ -1,0 +1,32 @@
+registerPaint(
+  "boxbg",
+  class {
+    static get contextOptions() {
+      return { alpha: true };
+    }
+
+    /*
+     use this function to retrieve any custom properties (or regular properties, such as 'height')
+     defined for the element, return them in the specified array
+  */
+    static get inputProperties() {
+      return ["--boxColor", "--widthSubtractor"];
+    }
+
+    paint(ctx, size, props) {
+      /*
+       ctx -> drawing context
+       size -> paintSize: width and height
+       props -> properties: get() method
+    */
+
+      ctx.fillStyle = props.get("--boxColor");
+      ctx.fillRect(
+        0,
+        size.height / 3,
+        size.width * 0.4 - props.get("--widthSubtractor"),
+        size.height * 0.6
+      );
+    }
+  }
+);

--- a/css-painting/custom-properties/index.html
+++ b/css-painting/custom-properties/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width" />
+
+    <title>CSS Painting API example</title>
+
+    <link rel="stylesheet" href="style.css" />
+    <script src="script.js" defer></script>
+  </head>
+
+  <body>
+    <ul>
+      <li>item 1</li>
+      <li>item 2</li>
+      <li>item 3</li>
+      <li>item 4</li>
+      <li>item 5</li>
+      <li>item 6</li>
+      <li>item 7</li>
+      <li>item 8</li>
+      <li>item 9</li>
+      <li>item 10</li>
+      <li>item 11</li>
+      <li>item 12</li>
+      <li>item 13</li>
+      <li>item 14</li>
+      <li>item 15</li>
+      <li>item 16</li>
+      <li>item 17</li>
+      <li>item</li>
+    </ul>
+  </body>
+</html>

--- a/css-painting/custom-properties/script.js
+++ b/css-painting/custom-properties/script.js
@@ -1,0 +1,1 @@
+CSS.paintWorklet.addModule("boxbg.js");

--- a/css-painting/custom-properties/style.css
+++ b/css-painting/custom-properties/style.css
@@ -1,0 +1,14 @@
+li {
+  background-image: paint(boxbg);
+  --boxColor: hsl(55 90% 60% / 1);
+}
+
+li:nth-of-type(3n) {
+  --boxColor: hsl(155 90% 60% / 1);
+  --widthSubtractor: 20;
+}
+
+li:nth-of-type(3n + 1) {
+  --boxColor: hsl(255 90% 60% / 1);
+  --widthSubtractor: 40;
+}

--- a/css-painting/fancy-header-highlight/header-highlight.js
+++ b/css-painting/fancy-header-highlight/header-highlight.js
@@ -1,0 +1,49 @@
+registerPaint(
+  "headerHighlight",
+  class {
+    static get inputProperties() {
+      return ["--highColor"];
+    }
+    static get contextOptions() {
+      return { alpha: true };
+    }
+
+    paint(ctx, size, props) {
+      /* set where to start the highlight & dimensions */
+      const x = 0;
+      const y = size.height * 0.3;
+      const blockWidth = size.width * 0.33;
+      const highlightHeight = size.height * 0.85;
+      const color = props.get("--highColor");
+
+      ctx.fillStyle = color;
+
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(blockWidth, y);
+      ctx.lineTo(blockWidth + highlightHeight, highlightHeight);
+      ctx.lineTo(x, highlightHeight);
+      ctx.lineTo(x, y);
+      ctx.closePath();
+      ctx.fill();
+
+      /* create the dashes */
+      for (let start = 0; start < 8; start += 2) {
+        ctx.beginPath();
+        ctx.moveTo(blockWidth + start * 10 + 10, y);
+        ctx.lineTo(blockWidth + start * 10 + 20, y);
+        ctx.lineTo(
+          blockWidth + start * 10 + 20 + highlightHeight,
+          highlightHeight
+        );
+        ctx.lineTo(
+          blockWidth + start * 10 + 10 + highlightHeight,
+          highlightHeight
+        );
+        ctx.lineTo(blockWidth + start * 10 + 10, y);
+        ctx.closePath();
+        ctx.fill();
+      }
+    } // paint
+  }
+);

--- a/css-painting/fancy-header-highlight/index.html
+++ b/css-painting/fancy-header-highlight/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width" />
+
+    <title>CSS Painting API example</title>
+
+    <link rel="stylesheet" href="style.css" />
+    <script src="script.js" defer></script>
+  </head>
+
+  <body>
+    <h1 class="fancy">Largest Header</h1>
+    <h3 class="fancy">Medium size header</h3>
+    <h6 class="fancy">Smallest Header</h6>
+  </body>
+</html>

--- a/css-painting/fancy-header-highlight/script.js
+++ b/css-painting/fancy-header-highlight/script.js
@@ -1,0 +1,1 @@
+CSS.paintWorklet.addModule("header-highlight.js");

--- a/css-painting/fancy-header-highlight/style.css
+++ b/css-painting/fancy-header-highlight/style.css
@@ -1,0 +1,12 @@
+.fancy {
+  background-image: paint(headerHighlight);
+}
+h1 {
+  --highColor: hsl(155 90% 60% / 0.7);
+}
+h3 {
+  --highColor: hsl(255 90% 60% / 0.5);
+}
+h6 {
+  --highColor: hsl(355 90% 60% / 0.3);
+}

--- a/css-painting/half-highlight-fixed-size/header-highlight.js
+++ b/css-painting/half-highlight-fixed-size/header-highlight.js
@@ -1,0 +1,22 @@
+registerPaint(
+  "headerHighlight",
+  class {
+    /*
+         define if alphatransparency is allowed alpha
+         is set to true by default. If set to false, all
+         colors used on the canvas will be fully opaque
+      */
+    static get contextOptions() {
+      return { alpha: true };
+    }
+
+    /*
+          ctx is the 2D drawing context
+          a subset of the HTML Canvas API.
+      */
+    paint(ctx) {
+      ctx.fillStyle = "hsl(55 90% 60% / 1.0)";
+      ctx.fillRect(0, 15, 200, 20); /* order: x, y, w, h */
+    }
+  }
+);

--- a/css-painting/half-highlight-fixed-size/index.html
+++ b/css-painting/half-highlight-fixed-size/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width" />
+
+    <title>CSS Painting API example</title>
+
+    <link rel="stylesheet" href="style.css" />
+    <script src="script.js" defer></script>
+  </head>
+
+  <body>
+    <h1 class="fancy">My Cool Header</h1>
+  </body>
+</html>

--- a/css-painting/half-highlight-fixed-size/script.js
+++ b/css-painting/half-highlight-fixed-size/script.js
@@ -1,0 +1,1 @@
+CSS.paintWorklet.addModule("header-highlight.js");

--- a/css-painting/half-highlight-fixed-size/style.css
+++ b/css-painting/half-highlight-fixed-size/style.css
@@ -1,0 +1,4 @@
+.fancy {
+    background-image: paint(headerHighlight);
+  }
+  

--- a/css-painting/half-highlight-paintsize/header-highlight.js
+++ b/css-painting/half-highlight-paintsize/header-highlight.js
@@ -1,0 +1,17 @@
+registerPaint(
+  "headerHighlight",
+  class {
+    static get contextOptions() {
+      return { alpha: true };
+    }
+
+    /*
+    ctx is the 2D drawing context
+    size is the paintSize, the dimensions (height and width) of the box being painted
+  */
+    paint(ctx, size) {
+      ctx.fillStyle = "hsl(55 90% 60% / 1.0)";
+      ctx.fillRect(0, size.height / 3, size.width * 0.4, size.height * 0.6);
+    }
+  }
+);

--- a/css-painting/half-highlight-paintsize/index.html
+++ b/css-painting/half-highlight-paintsize/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width" />
+
+    <title>CSS Painting API example</title>
+
+    <link rel="stylesheet" href="style.css" />
+    <script src="script.js" defer></script>
+  </head>
+
+  <body>
+    <h1 class="fancy">Largest Header</h1>
+    <h6 class="fancy">Smallest Header</h6>
+    <h3 class="fancy half">50% width header</h3>
+  </body>
+</html>

--- a/css-painting/half-highlight-paintsize/script.js
+++ b/css-painting/half-highlight-paintsize/script.js
@@ -1,0 +1,1 @@
+CSS.paintWorklet.addModule("header-highlight.js");

--- a/css-painting/half-highlight-paintsize/style.css
+++ b/css-painting/half-highlight-paintsize/style.css
@@ -1,0 +1,6 @@
+.fancy {
+  background-image: paint(headerHighlight);
+}
+.half {
+  width: 50%;
+}

--- a/css-painting/hollow-highlight/hollow.js
+++ b/css-painting/hollow-highlight/hollow.js
@@ -1,0 +1,72 @@
+registerPaint(
+  "hollowHighlights",
+  class {
+    static get inputProperties() {
+      return ["--boxColor"];
+    }
+    // Input arguments that can be passed to the `paint` function
+    static get inputArguments() {
+      return ["*", "<length>"];
+    }
+
+    static get contextOptions() {
+      return { alpha: true };
+    }
+
+    paint(ctx, size, props, args) {
+      // ctx   -> drawing context
+      // size  -> size of the box being painted
+      // props -> list of custom properties available to the element
+      // args  -> list of arguments set when calling the paint() function in the CSS
+
+      // where to start the highlight & dimensions
+      const x = 0;
+      const y = size.height * 0.3;
+      const blockWidth = size.width * 0.33;
+      const blockHeight = size.height * 0.85;
+
+      // the values passed in the paint() function in the CSS
+      const color = props.get("--boxColor");
+      const strokeType = args[0].toString();
+      const strokeWidth = parseInt(args[1]);
+
+      // set the stroke width
+      ctx.lineWidth = strokeWidth ?? 1.0;
+      // set the fill type
+      if (strokeType === "stroke") {
+        ctx.fillStyle = "transparent";
+        ctx.strokeStyle = color;
+      } else if (strokeType === "filled") {
+        ctx.fillStyle = color;
+        ctx.strokeStyle = color;
+      } else {
+        ctx.fillStyle = "none";
+        ctx.strokeStyle = "none";
+      }
+
+      // block
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(blockWidth, y);
+      ctx.lineTo(blockWidth + blockHeight, blockHeight);
+      ctx.lineTo(x, blockHeight);
+      ctx.lineTo(x, y);
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+      // dashes
+      for (let i = 0; i < 4; i++) {
+        let start = i * 2;
+        ctx.beginPath();
+        ctx.moveTo(blockWidth + start * 10 + 10, y);
+        ctx.lineTo(blockWidth + start * 10 + 20, y);
+        ctx.lineTo(blockWidth + start * 10 + 20 + blockHeight, blockHeight);
+        ctx.lineTo(blockWidth + start * 10 + 10 + blockHeight, blockHeight);
+        ctx.lineTo(blockWidth + start * 10 + 10, y);
+        ctx.closePath();
+        ctx.fill();
+        ctx.stroke();
+      }
+    } // paint
+  }
+);

--- a/css-painting/hollow-highlight/index.html
+++ b/css-painting/hollow-highlight/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width" />
+
+    <title>CSS Painting API example</title>
+
+    <link rel="stylesheet" href="style.css" />
+    <script src="script.js" defer></script>
+  </head>
+
+  <body>
+    <ul>
+      <li>item 1</li>
+      <li>item 2</li>
+      <li>item 3</li>
+      <li>item 4</li>
+      <li>item 5</li>
+      <li>item 6</li>
+      <li>item 7</li>
+      <li>item 8</li>
+      <li>item 9</li>
+      <li>item 10</li>
+      <li>item 11</li>
+      <li>item 12</li>
+      <li>item 13</li>
+      <li>item 14</li>
+      <li>item 15</li>
+      <li>item 16</li>
+      <li>item 17</li>
+      <li>item</li>
+    </ul>
+  </body>
+</html>

--- a/css-painting/hollow-highlight/script.js
+++ b/css-painting/hollow-highlight/script.js
@@ -1,0 +1,1 @@
+CSS.paintWorklet.addModule("hollow.js");

--- a/css-painting/hollow-highlight/style.css
+++ b/css-painting/hollow-highlight/style.css
@@ -1,0 +1,14 @@
+li {
+  --boxColor: hsl(155 90% 60% / 0.5);
+  background-image: paint(hollowHighlights, stroke, 5px);
+}
+
+li:nth-of-type(3n) {
+  --boxColor: hsl(255 90% 60% / 0.5);
+  background-image: paint(hollowHighlights, filled, 3px);
+}
+
+li:nth-of-type(3n + 1) {
+  --boxColor: hsl(355 90% 60% / 0.5);
+  background-image: paint(hollowHighlights, stroke, 1px);
+}

--- a/css-painting/index.html
+++ b/css-painting/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width" />
+
+    <title>CSS Painting API examples</title>
+
+    <link rel="stylesheet" href="style.css" />
+    <script src="script.js" defer></script>
+  </head>
+
+  <body>
+    <ul>
+      <li>
+        <a href="half-highlight-fixed-size">Half highlight, fixed size</a>
+      </li>
+      <li>
+        <a href="half-highlight-paintsize">Half highlight, variable size</a>
+      </li>
+      <li><a href="fancy-header-highlight">Fancy highlight</a></li>
+      <li><a href="custom-properties">Using custom properties</a></li>
+      <li><a href="hollow-highlight">Hollow highlight</a></li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
This is part of the fix for https://github.com/mdn/content/issues/23394, in which it is reported that the CSS Painting API examples don't work due to CORS problems loading the worklets.

So here we move the examples into the dom-examples repo so we can embed them using EmbedGHLiveSample.

I've set up the GitHub pages for my fork so you can see them at https://wbamberg.github.io/dom-examples/css-painting/ - of course you'll need Chrome/Edge for them to work, and the last example also needs the "Experimental Web Platform features" flag set.
