### PR TITLE
Refactor target identifier logic

### DIFF
--- a/view-transitions/script.js
+++ b/view-transitions/script.js
@@ -42,12 +42,7 @@ function init() {
 
 function updateView(event) {
   // Handle the difference in whether the event is fired on the <a> or the <img>
-  let targetIdentifier;
-  if (event.target.firstChild === null) {
-    targetIdentifier = event.target;
-  } else {
-    targetIdentifier = event.target.firstChild;
-  }
+  const targetIdentifier = event.target.firstChild || event.target;
 
   const displayNewImage = () => {
     const mainSrc = `${targetIdentifier.src.split("_th.jpg")[0]}.jpg`;


### PR DESCRIPTION
### Description
The previous implementation used an if statement to check whether the event target had a first child or not before assigning it to the `targetIdentifier` variable. This was replaced with a simplified implementation that uses a logical OR operator to assign the first child or the target itself to `targetIdentifier`.

related https://github.com/mdn/content/pull/25149