### PR TITLE
Use `u` sufix for buffer_size literal

### DIFF
--- a/webgpu-compute-demo/script.js
+++ b/webgpu-compute-demo/script.js
@@ -15,7 +15,7 @@ fn main(
   local_id : vec3u,
 ) {
   // Avoid accessing the buffer out of bounds
-  if (global_id.x >= ${BUFFER_SIZE}) {
+  if (global_id.x >= ${BUFFER_SIZE}u) {
     return;
   }
 


### PR DESCRIPTION
Without this, webgpu compute example does not work in Firefox, because naga (wgsl parsing library used in Firefox) [does not support automatic type conversations](https://github.com/gfx-rs/naga/issues/2127) yet.

Test deployment: https://sagudev.github.io/dom-examples/webgpu-compute-demo/