### PR TITLE
Add demo for Document Picture-In-Picture API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 * The "drag-and-drop" directory is for examples and demos of the [HTML Drag and Drop](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API) standard.
 
+* The "document-picture-in-picture" directory contains an example showing usage of the [Document Picture-in-Picture API](http://developer.mozilla.org/en-US/docs/Web/API/Document_Picture-in-Picture_API/). [See the example live](https://mdn.github.io/dom-examples/document-picture-in-picture/).
+
 * The "fullscreen-api" directory is for examples and demos of the [Fullscreen API](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API). Run the [example live](https://mdn.github.io/dom-examples/fullscreen-api/).
 
 * The "indexeddb-api" directory contains a demo for the [IndexedDB API](https://mdn.github.io/dom-examples/indexeddb-api/index.html).

--- a/document-picture-in-picture/README.md
+++ b/document-picture-in-picture/README.md
@@ -1,0 +1,5 @@
+# Document Picture-in-Picture example
+
+This example will progressively enhance a video by adding a toggle picture-in-picture button if the [Document Picture-in-Picture API](http://developer.mozilla.org/en-US/docs/Web/API/Document_Picture-in-Picture_API/) is available.
+
+[See the example live](https://mdn.github.io/dom-examples/document-picture-in-picture/).

--- a/document-picture-in-picture/index.html
+++ b/document-picture-in-picture/index.html
@@ -11,7 +11,7 @@
   <div id="contents">
     <h1>Document Picture-in-Picture API Example</h1>
     <div id="container">
-      <p class="in-pip-message">Video player is currently in the separate Picture-in-Picture window.</p>
+      <p id="in-pip-message">Video player is currently in the separate Picture-in-Picture window.</p>
       <div id="player">
         <video src="assets/bigbuckbunny.mp4" id="video" controls width="320"></video>
 

--- a/document-picture-in-picture/index.html
+++ b/document-picture-in-picture/index.html
@@ -11,6 +11,7 @@
   <div id="contents">
     <h1>Document Picture-in-Picture API Example</h1>
     <div id="container">
+      <p class="in-pip-message">Video player is currently in the separate Picture-in-Picture window.</p>
       <div id="player">
         <video src="assets/bigbuckbunny.mp4" id="video" controls width="320"></video>
 

--- a/document-picture-in-picture/index.html
+++ b/document-picture-in-picture/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <title>Document Picture-in-Picture API Example</title>
+  <script src="main.js" async></script>
+  <link href="main.css" rel="stylesheet">
+</head>
+
+<body>
+  <div id="contents">
+    <h1>Document Picture-in-Picture API Example</h1>
+    <div id="container">
+      <div id="player">
+        <video src="assets/bigbuckbunny.mp4" id="video" controls width="320"></video>
+
+        <div id="credits"><a href="https://peach.blender.org/download/" target="_blank">Video by Blender</a>;
+          <a href="https://peach.blender.org/about/" target="_blank">licensed CC-BY 3.0</a>
+        </div>
+
+        <div id="controlbar">
+          <p class="no-picture-in-picture">
+            Document Picture-in-Picture API not available
+          <p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/document-picture-in-picture/main.css
+++ b/document-picture-in-picture/main.css
@@ -1,0 +1,9 @@
+#contents {
+	width: 600px;
+	font: 14px "Open Sans", sans-serif;
+}
+
+#credits {
+	padding: 0 0 10px 0;
+	font: italic 10px "Open Sans", sans-serif;
+}

--- a/document-picture-in-picture/main.css
+++ b/document-picture-in-picture/main.css
@@ -7,3 +7,7 @@
 	padding: 0 0 10px 0;
 	font: italic 10px "Open Sans", sans-serif;
 }
+
+#in-pip-message {
+	display: none;
+}

--- a/document-picture-in-picture/main.js
+++ b/document-picture-in-picture/main.js
@@ -1,0 +1,90 @@
+
+const videoPlayer = document.getElementById("player");
+const playerContainer = document.getElementById("container");
+let togglePipButton;
+let pipActive = false;
+let pipWindow;
+
+const inPIPMessage = document.createElement("p");
+inPIPMessage.textContent = "Video player is currently in the separate Picture-in-Picture window";
+
+if ("documentPictureInPicture" in window) {
+
+	document.querySelector(".no-picture-in-picture").remove();
+
+	togglePipButton = document.createElement("button");
+	togglePipButton.textContent = "Toggle Picture-in-Picture";
+	togglePipButton.addEventListener("click", togglePictureInPicture, false);
+
+	document.getElementById("controlbar").appendChild(togglePipButton);
+}
+
+async function togglePictureInPicture() {
+	if (!pipActive) {
+		pipActive = true;
+
+		// Open a Picture-in-Picture window.
+		pipWindow = await documentPictureInPicture.requestWindow({
+			width: videoPlayer.clientWidth,
+			height: videoPlayer.clientHeight,
+		});
+
+		// Add pagehide listener to handle the case of the pip window being closed using the browser X button
+		pipWindow.addEventListener("pagehide", (event) => {
+			pipActive = false;
+			inPIPMessage.remove();
+			playerContainer.append(videoPlayer);
+		});
+
+		// Copy style sheets over from the initial document
+		// so that the player looks the same.
+		[...document.styleSheets].forEach((styleSheet) => {
+			try {
+				const cssRules = [...styleSheet.cssRules].map((rule) => rule.cssText).join('');
+				const style = document.createElement('style');
+
+				style.textContent = cssRules;
+				pipWindow.document.head.appendChild(style);
+			} catch (e) {
+				const link = document.createElement('link');
+
+				link.rel = 'stylesheet';
+				link.type = styleSheet.type;
+				link.media = styleSheet.media;
+				link.href = styleSheet.href;
+				pipWindow.document.head.appendChild(link);
+			}
+		})
+
+		// Move the player to the Picture-in-Picture window.
+		pipWindow.document.body.append(videoPlayer);
+
+		// Display a message to say it has been moved
+		playerContainer.append(inPIPMessage);
+	} else {
+		pipActive = false;
+		inPIPMessage.remove();
+		playerContainer.append(videoPlayer);
+		window.documentPictureInPicture.window.close();
+	}
+}
+
+documentPictureInPicture.addEventListener("enter", (event) => {
+	const pipWindow = event.window;
+	console.log("Video player has entered the pip window");
+
+	const pipMuteButton = pipWindow.document.createElement("button");
+	pipMuteButton.textContent = "Mute";
+	pipMuteButton.addEventListener("click", () => {
+		const pipVideo = pipWindow.document.querySelector("#video");
+		if (!pipVideo.muted) {
+			pipVideo.muted = true;
+			pipMuteButton.textContent = "Unmute";
+		} else {
+			pipVideo.muted = false;
+			pipMuteButton.textContent = "Mute";
+		}
+	});
+
+	pipWindow.document.body.append(pipMuteButton);
+});

--- a/document-picture-in-picture/main.js
+++ b/document-picture-in-picture/main.js
@@ -6,7 +6,7 @@ let pipActive = false;
 let pipWindow;
 
 const inPIPMessage = document.createElement("p");
-inPIPMessage.textContent = "Video player is currently in the separate Picture-in-Picture window";
+inPIPMessage.textContent = "Video player is currently in the separate Picture-in-Picture window.";
 
 if ("documentPictureInPicture" in window) {
 
@@ -24,7 +24,7 @@ async function togglePictureInPicture() {
 		pipActive = true;
 
 		// Open a Picture-in-Picture window.
-		pipWindow = await documentPictureInPicture.requestWindow({
+		pipWindow = await window.documentPictureInPicture.requestWindow({
 			width: videoPlayer.clientWidth,
 			height: videoPlayer.clientHeight,
 		});

--- a/document-picture-in-picture/main.js
+++ b/document-picture-in-picture/main.js
@@ -17,6 +17,7 @@ if ("documentPictureInPicture" in window) {
 }
 
 async function togglePictureInPicture() {
+	// Returns null if no pip window is currently open
 	if (!window.documentPictureInPicture.window) {
 
 		// Open a Picture-in-Picture window.

--- a/document-picture-in-picture/main.js
+++ b/document-picture-in-picture/main.js
@@ -2,8 +2,8 @@
 const videoPlayer = document.getElementById("player");
 const playerContainer = document.getElementById("container");
 
-const inPIPMessage = document.querySelector(".in-pip-message");
-inPIPMessage.style.display = "none";
+const inPipMessage = document.querySelector(".in-pip-message");
+inPipMessage.style.display = "none";
 
 if ("documentPictureInPicture" in window) {
 
@@ -27,7 +27,7 @@ async function togglePictureInPicture() {
 
 		// Add pagehide listener to handle the case of the pip window being closed using the browser X button
 		pipWindow.addEventListener("pagehide", (event) => {
-			inPIPMessage.style.display = "none";
+			inPipMessage.style.display = "none";
 			playerContainer.append(videoPlayer);
 		});
 
@@ -55,9 +55,9 @@ async function togglePictureInPicture() {
 		pipWindow.document.body.append(videoPlayer);
 
 		// Display a message to say it has been moved
-		inPIPMessage.style.display = "block";
+		inPipMessage.style.display = "block";
 	} else {
-		inPIPMessage.style.display = "none";
+		inPipMessage.style.display = "none";
 		playerContainer.append(videoPlayer);
 		window.documentPictureInPicture.window.close();
 	}

--- a/document-picture-in-picture/main.js
+++ b/document-picture-in-picture/main.js
@@ -2,8 +2,7 @@
 const videoPlayer = document.getElementById("player");
 const playerContainer = document.getElementById("container");
 
-const inPipMessage = document.querySelector(".in-pip-message");
-inPipMessage.style.display = "none";
+const inPipMessage = document.getElementById("in-pip-message");
 
 if ("documentPictureInPicture" in window) {
 

--- a/document-picture-in-picture/main.js
+++ b/document-picture-in-picture/main.js
@@ -1,18 +1,15 @@
 
 const videoPlayer = document.getElementById("player");
 const playerContainer = document.getElementById("container");
-let togglePipButton;
-let pipActive = false;
-let pipWindow;
 
-const inPIPMessage = document.createElement("p");
-inPIPMessage.textContent = "Video player is currently in the separate Picture-in-Picture window.";
+const inPIPMessage = document.querySelector(".in-pip-message");
+inPIPMessage.style.display = "none";
 
 if ("documentPictureInPicture" in window) {
 
 	document.querySelector(".no-picture-in-picture").remove();
 
-	togglePipButton = document.createElement("button");
+	const togglePipButton = document.createElement("button");
 	togglePipButton.textContent = "Toggle Picture-in-Picture";
 	togglePipButton.addEventListener("click", togglePictureInPicture, false);
 
@@ -20,19 +17,17 @@ if ("documentPictureInPicture" in window) {
 }
 
 async function togglePictureInPicture() {
-	if (!pipActive) {
-		pipActive = true;
+	if (!window.documentPictureInPicture.window) {
 
 		// Open a Picture-in-Picture window.
-		pipWindow = await window.documentPictureInPicture.requestWindow({
+		const pipWindow = await window.documentPictureInPicture.requestWindow({
 			width: videoPlayer.clientWidth,
 			height: videoPlayer.clientHeight,
 		});
 
 		// Add pagehide listener to handle the case of the pip window being closed using the browser X button
 		pipWindow.addEventListener("pagehide", (event) => {
-			pipActive = false;
-			inPIPMessage.remove();
+			inPIPMessage.style.display = "none";
 			playerContainer.append(videoPlayer);
 		});
 
@@ -60,10 +55,9 @@ async function togglePictureInPicture() {
 		pipWindow.document.body.append(videoPlayer);
 
 		// Display a message to say it has been moved
-		playerContainer.append(inPIPMessage);
+		inPIPMessage.style.display = "block";
 	} else {
-		pipActive = false;
-		inPIPMessage.remove();
+		inPIPMessage.style.display = "none";
 		playerContainer.append(videoPlayer);
 		window.documentPictureInPicture.window.close();
 	}


### PR DESCRIPTION
The [Document Picture-In-Picture API](https://wicg.github.io/document-picture-in-picture) is supported in Chrome 116 (see [ChromeStatus entry](https://chromestatus.com/feature/5755179560337408); I have also tested it). I am currently working on the documentation for it, and also wanted to add a demo to reference, to this repo.