### PR TITLE
fix: history-api demo

### DIFF
--- a/history-api/index.html
+++ b/history-api/index.html
@@ -8,7 +8,7 @@
 
   <body>
     <ul class="nav">
-      <li><a href="/">Home</a></li>
+      <li><a href="/dom-examples/history-api/">Home</a></li>
       <li><a href="eagle.html" data-creature="eagle">Eagle</a></li>
       <li><a href="vulture.html" data-creature="vulture">Vulture</a></li>
       <li><a href="turtle.html" data-creature="turtle">Turtle</a></li>

--- a/history-api/index.html
+++ b/history-api/index.html
@@ -15,9 +15,9 @@
   <body>
     <ul class="nav">
       <li><a href="/dom-examples/history-api/">Home</a></li>
-      <li><a href="eagle.html" data-creature="eagle">Eagle</a></li>
-      <li><a href="vulture.html" data-creature="vulture">Vulture</a></li>
-      <li><a href="turtle.html" data-creature="turtle">Turtle</a></li>
+      <li><a href="eagle" data-creature="eagle">Eagle</a></li>
+      <li><a href="vulture" data-creature="vulture">Vulture</a></li>
+      <li><a href="turtle" data-creature="turtle">Turtle</a></li>
     </ul>
 
     <p id="description">Let's look at some creatures.</p>

--- a/history-api/index.html
+++ b/history-api/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <title>Creatures: Home</title>
     <script src="script.js" defer></script>
+    <style>
+      .nav li {
+        display: inline-block;
+        margin-right: 2rem;
+      }
+    </style>
   </head>
 
   <body>

--- a/history-api/script.js
+++ b/history-api/script.js
@@ -23,7 +23,7 @@ document.addEventListener("click", async (event) => {
       displayContent(json);
       // Add a new entry to the history.
       // This simulates loading a new page.
-      history.pushState(json, "", `${creature}.html`);
+      history.pushState(json, "", creature);
     } catch (err) {
       console.error(err);
     }

--- a/history-api/script.js
+++ b/history-api/script.js
@@ -23,7 +23,7 @@ document.addEventListener("click", async (event) => {
       displayContent(json);
       // Add a new entry to the history.
       // This simulates loading a new page.
-      history.pushState(json, "", creature);
+      history.pushState(json, "", `${creature}.html`);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
Some issues to fix:
- Considering the demo is hosted at https://mdn.github.io/dom-examples/history-api/ , the home page link is giving 404.
- Links are advertised as `*.html` but they reach non .html destinations.

/cc @wbamberg 