### PR TITLE
Transfer SourceBuffer example from https://github.com/nickdesaulniers…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "server-sent-events" directory contains a very basic SSE demo that uses PHP to create the server. You can find more information in our [Using server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) article. To run the demo you'll need to serve the files from a server that supports PHP; [MAMP](https://www.mamp.info/en/) is a good PHP test server environment.
 
+- The "sourcebuffer" directory contains a basic demo to show usage of the [`SourceBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/SourceBuffer) interface. [Run the demo live](https://mdn.github.io/dom-examples/sourcebuffer/).
+
 - The "streams" directory contains demos of the Streams API for using low-level I/O processing.
 
 - The "touchevents" directory is for examples and demos of the [Touch Events](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events) standard.

--- a/sourcebuffer/index.html
+++ b/sourcebuffer/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>SourceBuffer example</title>
+    <script src="script.js" defer></script>
+  </head>
+  <body>
+    <video controls></video>
+    <div>
+      <button id="load">Load</button>
+    </div>
+  </body>
+</html>

--- a/sourcebuffer/script.js
+++ b/sourcebuffer/script.js
@@ -1,0 +1,33 @@
+const video = document.querySelector("video");
+
+const assetURL = "frag_bunny.mp4";
+// Need to be specific for Blink regarding codecs
+const mimeCodec = 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"';
+
+function loadVideo() {
+  if (MediaSource.isTypeSupported(mimeCodec)) {
+    const mediaSource = new MediaSource();
+    console.log(mediaSource.readyState); // closed
+    video.src = URL.createObjectURL(mediaSource);
+    mediaSource.addEventListener("sourceopen", sourceOpen);
+  } else {
+    console.error("Unsupported MIME type or codec: ", mimeCodec);
+  }
+}
+
+async function sourceOpen() {
+  console.log(this.readyState); // open
+  const mediaSource = this;
+  const sourceBuffer = mediaSource.addSourceBuffer(mimeCodec);
+  const response = await fetch(assetURL);
+  const buffer = await response.arrayBuffer();
+  sourceBuffer.addEventListener("updateend", () => {
+    mediaSource.endOfStream();
+    video.play();
+    console.log(mediaSource.readyState); // ended
+  });
+  sourceBuffer.appendBuffer(buffer);
+}
+
+const load = document.querySelector("#load");
+load.addEventListener("click", loadVideo);


### PR DESCRIPTION
This is a leftover bit of https://github.com/mdn/content/pull/30423, in which we move the example from https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferAll.html to this repo, where we can maintain it.

The JS in this version matches that in the page at https://developer.mozilla.org/en-US/docs/Web/API/SourceBuffer#examples, I hope we haven't mangled it over the years.

See also https://github.com/nickdesaulniers/netfix/issues/10, where this transfer was discussed. Thanks @nickdesaulniers !