### PR TITLE
Don't hardcode MIME type in web-dictaphone

### DIFF
--- a/media/web-dictaphone/scripts/app.js
+++ b/media/web-dictaphone/scripts/app.js
@@ -77,7 +77,7 @@ if (navigator.mediaDevices.getUserMedia) {
       soundClips.appendChild(clipContainer);
 
       audio.controls = true;
-      const blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
+      const blob = new Blob(chunks, { 'type' : mediaRecorder.mimeType });
       chunks = [];
       const audioURL = window.URL.createObjectURL(blob);
       audio.src = audioURL;

--- a/media/web-dictaphone/scripts/app.js
+++ b/media/web-dictaphone/scripts/app.js
@@ -14,7 +14,7 @@ const canvasCtx = canvas.getContext("2d");
 
 // Main block for doing the audio recording
 if (navigator.mediaDevices.getUserMedia) {
-  console.log('The mediaDevices.getUserMedia() media is supported.');
+  console.log('The mediaDevices.getUserMedia() method is supported.');
 
   const constraints = { audio: true };
   let chunks = [];

--- a/media/web-dictaphone/scripts/app.js
+++ b/media/web-dictaphone/scripts/app.js
@@ -1,9 +1,9 @@
 // Set up basic variables for app
-const record = document.querySelector('.record');
-const stop = document.querySelector('.stop');
-const soundClips = document.querySelector('.sound-clips');
-const canvas = document.querySelector('.visualizer');
-const mainSection = document.querySelector('.main-controls');
+const record = document.querySelector(".record");
+const stop = document.querySelector(".stop");
+const soundClips = document.querySelector(".sound-clips");
+const canvas = document.querySelector(".visualizer");
+const mainSection = document.querySelector(".main-controls");
 
 // Disable stop button while not recording
 stop.disabled = true;
@@ -14,17 +14,17 @@ const canvasCtx = canvas.getContext("2d");
 
 // Main block for doing the audio recording
 if (navigator.mediaDevices.getUserMedia) {
-  console.log('The mediaDevices.getUserMedia() method is supported.');
+  console.log("The mediaDevices.getUserMedia() method is supported.");
 
   const constraints = { audio: true };
   let chunks = [];
 
-  let onSuccess = function(stream) {
+  let onSuccess = function (stream) {
     const mediaRecorder = new MediaRecorder(stream);
 
     visualize(stream);
 
-    record.onclick = function() {
+    record.onclick = function () {
       mediaRecorder.start();
       console.log(mediaRecorder.state);
       console.log("Recorder started.");
@@ -32,9 +32,9 @@ if (navigator.mediaDevices.getUserMedia) {
 
       stop.disabled = false;
       record.disabled = true;
-    }
+    };
 
-    stop.onclick = function() {
+    stop.onclick = function () {
       mediaRecorder.stop();
       console.log(mediaRecorder.state);
       console.log("Recorder stopped.");
@@ -43,25 +43,28 @@ if (navigator.mediaDevices.getUserMedia) {
 
       stop.disabled = true;
       record.disabled = false;
-    }
+    };
 
-    mediaRecorder.onstop = function(e) {
+    mediaRecorder.onstop = function (e) {
       console.log("Last data to read (after MediaRecorder.stop() called).");
 
-      const clipName = prompt('Enter a name for your sound clip?','My unnamed clip');
+      const clipName = prompt(
+        "Enter a name for your sound clip?",
+        "My unnamed clip"
+      );
 
-      const clipContainer = document.createElement('article');
-      const clipLabel = document.createElement('p');
-      const audio = document.createElement('audio');
-      const deleteButton = document.createElement('button');
+      const clipContainer = document.createElement("article");
+      const clipLabel = document.createElement("p");
+      const audio = document.createElement("audio");
+      const deleteButton = document.createElement("button");
 
-      clipContainer.classList.add('clip');
-      audio.setAttribute('controls', '');
-      deleteButton.textContent = 'Delete';
-      deleteButton.className = 'delete';
+      clipContainer.classList.add("clip");
+      audio.setAttribute("controls", "");
+      deleteButton.textContent = "Delete";
+      deleteButton.className = "delete";
 
-      if(clipName === null) {
-        clipLabel.textContent = 'My unnamed clip';
+      if (clipName === null) {
+        clipLabel.textContent = "My unnamed clip";
       } else {
         clipLabel.textContent = clipName;
       }
@@ -72,44 +75,43 @@ if (navigator.mediaDevices.getUserMedia) {
       soundClips.appendChild(clipContainer);
 
       audio.controls = true;
-      const blob = new Blob(chunks, { 'type' : mediaRecorder.mimeType });
+      const blob = new Blob(chunks, { type: mediaRecorder.mimeType });
       chunks = [];
       const audioURL = window.URL.createObjectURL(blob);
       audio.src = audioURL;
       console.log("recorder stopped");
 
-      deleteButton.onclick = function(e) {
+      deleteButton.onclick = function (e) {
         e.target.closest(".clip").remove();
-      }
+      };
 
-      clipLabel.onclick = function() {
+      clipLabel.onclick = function () {
         const existingName = clipLabel.textContent;
-        const newClipName = prompt('Enter a new name for your sound clip?');
-        if(newClipName === null) {
+        const newClipName = prompt("Enter a new name for your sound clip?");
+        if (newClipName === null) {
           clipLabel.textContent = existingName;
         } else {
           clipLabel.textContent = newClipName;
         }
-      }
-    }
+      };
+    };
 
-    mediaRecorder.ondataavailable = function(e) {
+    mediaRecorder.ondataavailable = function (e) {
       chunks.push(e.data);
-    }
-  }
+    };
+  };
 
-  let onError = function(err) {
-    console.log('The following error occured: ' + err);
-  }
+  let onError = function (err) {
+    console.log("The following error occured: " + err);
+  };
 
   navigator.mediaDevices.getUserMedia(constraints).then(onSuccess, onError);
-
 } else {
-   console.log('MediaDevices.getUserMedia() not supported on your browser!');
+  console.log("MediaDevices.getUserMedia() not supported on your browser!");
 }
 
 function visualize(stream) {
-  if(!audioCtx) {
+  if (!audioCtx) {
     audioCtx = new AudioContext();
   }
 
@@ -122,34 +124,32 @@ function visualize(stream) {
 
   source.connect(analyser);
 
-  draw()
+  draw();
 
   function draw() {
-    const WIDTH = canvas.width
+    const WIDTH = canvas.width;
     const HEIGHT = canvas.height;
 
     requestAnimationFrame(draw);
 
     analyser.getByteTimeDomainData(dataArray);
 
-    canvasCtx.fillStyle = 'rgb(200, 200, 200)';
+    canvasCtx.fillStyle = "rgb(200, 200, 200)";
     canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
 
     canvasCtx.lineWidth = 2;
-    canvasCtx.strokeStyle = 'rgb(0, 0, 0)';
+    canvasCtx.strokeStyle = "rgb(0, 0, 0)";
 
     canvasCtx.beginPath();
 
-    let sliceWidth = WIDTH * 1.0 / bufferLength;
+    let sliceWidth = (WIDTH * 1.0) / bufferLength;
     let x = 0;
 
-
-    for(let i = 0; i < bufferLength; i++) {
-
+    for (let i = 0; i < bufferLength; i++) {
       let v = dataArray[i] / 128.0;
-      let y = v * HEIGHT/2;
+      let y = (v * HEIGHT) / 2;
 
-      if(i === 0) {
+      if (i === 0) {
         canvasCtx.moveTo(x, y);
       } else {
         canvasCtx.lineTo(x, y);
@@ -158,14 +158,13 @@ function visualize(stream) {
       x += sliceWidth;
     }
 
-    canvasCtx.lineTo(canvas.width, canvas.height/2);
+    canvasCtx.lineTo(canvas.width, canvas.height / 2);
     canvasCtx.stroke();
-
   }
 }
 
-window.onresize = function() {
+window.onresize = function () {
   canvas.width = mainSection.offsetWidth;
-}
+};
 
 window.onresize();

--- a/media/web-dictaphone/scripts/app.js
+++ b/media/web-dictaphone/scripts/app.js
@@ -1,24 +1,20 @@
-// set up basic variables for app
-
+// Set up basic variables for app
 const record = document.querySelector('.record');
 const stop = document.querySelector('.stop');
 const soundClips = document.querySelector('.sound-clips');
 const canvas = document.querySelector('.visualizer');
 const mainSection = document.querySelector('.main-controls');
 
-// disable stop button while not recording
-
+// Disable stop button while not recording
 stop.disabled = true;
 
-// visualiser setup - create web audio api context and canvas
-
+// Visualiser setup - create web audio api context and canvas
 let audioCtx;
 const canvasCtx = canvas.getContext("2d");
 
-//main block for doing the audio recording
-
+// Main block for doing the audio recording
 if (navigator.mediaDevices.getUserMedia) {
-  console.log('getUserMedia supported.');
+  console.log('The mediaDevices.getUserMedia() media is supported.');
 
   const constraints = { audio: true };
   let chunks = [];
@@ -31,7 +27,7 @@ if (navigator.mediaDevices.getUserMedia) {
     record.onclick = function() {
       mediaRecorder.start();
       console.log(mediaRecorder.state);
-      console.log("recorder started");
+      console.log("Recorder started.");
       record.style.background = "red";
 
       stop.disabled = false;
@@ -41,17 +37,16 @@ if (navigator.mediaDevices.getUserMedia) {
     stop.onclick = function() {
       mediaRecorder.stop();
       console.log(mediaRecorder.state);
-      console.log("recorder stopped");
+      console.log("Recorder stopped.");
       record.style.background = "";
       record.style.color = "";
-      // mediaRecorder.requestData();
 
       stop.disabled = true;
       record.disabled = false;
     }
 
     mediaRecorder.onstop = function(e) {
-      console.log("data available after MediaRecorder.stop() called.");
+      console.log("Last data to read (after MediaRecorder.stop() called).");
 
       const clipName = prompt('Enter a name for your sound clip?','My unnamed clip');
 
@@ -110,7 +105,7 @@ if (navigator.mediaDevices.getUserMedia) {
   navigator.mediaDevices.getUserMedia(constraints).then(onSuccess, onError);
 
 } else {
-   console.log('getUserMedia not supported on your browser!');
+   console.log('MediaDevices.getUserMedia() not supported on your browser!');
 }
 
 function visualize(stream) {
@@ -126,7 +121,6 @@ function visualize(stream) {
   const dataArray = new Uint8Array(bufferLength);
 
   source.connect(analyser);
-  //analyser.connect(audioCtx.destination);
 
   draw()
 


### PR DESCRIPTION
Fixes #233

The problem was that the MIME type was not supported on Safari.

[f789f3f](https://github.com/mdn/dom-examples/commit/f789f3fafdd28705289514f7aa2213e98ff9c1a2) Instead of hardcoding it, I now use the MIME type of the `MediaRecorder` object, they will match on every browser.

I also cleaned comments and logs to match our most recent standard in [5f87061](https://github.com/mdn/dom-examples/pull/241/commits/5f8706157fbaa6f70826b6c549524a7f1fac5638).

I tested locally in Firefox and Safari, using a VSCode extension:

![Capture d’écran 2023-12-20 à 11 27 38](https://github.com/mdn/dom-examples/assets/1466293/62810128-5ebc-4a19-bc41-be941cc5e862)

