### PR TITLE
Add Shadow DOM examples

### DIFF
--- a/shadow-dom/README.md
+++ b/shadow-dom/README.md
@@ -1,0 +1,4 @@
+# Shadow DOM
+
+- [Simple `<template shadowrootmode="open">` example](https://mdn.github.io/dom-examples/shadow-dom/shadowrootmode/simple.html)
+- [CSS scoping with `<template shadowrootmode="open">`](https://mdn.github.io/dom-examples/shadow-dom/shadowrootmode/scoping.html)

--- a/shadow-dom/shadowrootmode/scoping.html
+++ b/shadow-dom/shadowrootmode/scoping.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CSS scoping in declarative shadow DOM</title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <p hidden>⛔ Your browser doesn't support <code>shadowrootmode</code> attribute yet.</p>
+    <article>
+      <style>
+        p {
+          padding: 8px;
+          background-color: wheat;
+        }
+      </style>
+      <p>I'm in the DOM.</p>
+    </article>
+    <article>
+      <template shadowrootmode="open">
+        <style>
+          p {
+            padding: 8px;
+            background-color: plum;
+          }
+        </style>
+        <p>I'm in the Shadow DOM.</p>
+      </template>
+    </article>
+
+    <script>
+      const isShadowRootModeSupported = HTMLTemplateElement.prototype.hasOwnProperty('shadowRootMode');
+
+      document.querySelector('p[hidden]').toggleAttribute('hidden', isShadowRootModeSupported);
+    </script>
+    <!--
+      Used in:
+      - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
+    -->
+  </body>
+</html>

--- a/shadow-dom/shadowrootmode/simple.html
+++ b/shadow-dom/shadowrootmode/simple.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Declarative shadow DOM</title>
+  </head>
+  <body>
+    <div id="host">
+      <template shadowrootmode="open">
+        <span>I'm in the shadow DOM</span>
+      </template>
+    </div>
+    <!--
+      Used in:
+      - https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM
+    -->
+  </body>
+</html>


### PR DESCRIPTION
> ⚠️ The same demos were already merged in https://github.com/mdn/interactive-examples/pull/2707 but didn’t work as expected. Once these are merged, I’ll remove the previous ones.

### Description

Adds declarative shadow DOM examples that can only work with `{{EmbedGHLiveSample}}` macros as remote demos.

### Motivation

To support existing implementations in Chrome and Safari and for the upcoming one in Firefox 122 (behind the flag).

### Related issues and pull requests

- https://github.com/mdn/content/pull/31577
- https://github.com/mdn/content/pull/31490