### PR TITLE
Make sample compatible with older browers (specifically IE11)

### DIFF
--- a/web-workers/fibonacci-worker/fibonacci.js
+++ b/web-workers/fibonacci-worker/fibonacci.js
@@ -1,4 +1,4 @@
-self.onmessage = (event) => {
+self.onmessage =  function(event) {
   const userNum = Number(event.data);
   self.postMessage(fibonacci(userNum));
 };
@@ -7,7 +7,9 @@ function fibonacci(num) {
   let a = 1;
   let b = 0;
   while (num > 0) {
-    [a, b] = [a + b, a];
+	a = a+b;
+    b = a-b; // Current a is previous a+ previous b
+			 // In modern JS: [a,b] = [a+b,a]
     num--;
   }
 

--- a/web-workers/fibonacci-worker/fibonacci.js
+++ b/web-workers/fibonacci-worker/fibonacci.js
@@ -7,9 +7,9 @@ function fibonacci(num) {
   let a = 1;
   let b = 0;
   while (num > 0) {
-	a = a+b;
-    b = a-b; // Current a is previous a+ previous b
-			 // In modern JS: [a,b] = [a+b,a]
+  a = a+b;
+  b = a-b; // Current a is previous a+ previous b
+           // In modern JS: [a,b] = [a+b,a]
     num--;
   }
 

--- a/web-workers/fibonacci-worker/index.html
+++ b/web-workers/fibonacci-worker/index.html
@@ -44,7 +44,7 @@
       };
 
       worker.onerror = function (error) {
-        console.log(`Worker error: ${error.message} \n`);
+        console.log("Worker error: "+error.message+"\n");
         throw error;
       };
 


### PR DESCRIPTION
The sample was using ES6 features not relevant to the purpose of the sample :
- arrow functions
- `this kind of ${"string formatting"}`
- destructured assignation, i.e. [a,b] = [a+b,a]

I replaced the first two features with vintage JavaScript and the third one with a traditional hack that should convince people that destructured assignement is a valuable improvement of JS.

It now runs with IE11.