### PR TITLE
service-worker: await unnecessary, errors should be handled

### DIFF
--- a/service-worker/simple-service-worker/sw.js
+++ b/service-worker/simple-service-worker/sw.js
@@ -1,11 +1,11 @@
 const addResourcesToCache = async (resources) => {
   const cache = await caches.open('v1');
-  await cache.addAll(resources);
+  cache.addAll(resources).catch(err => console.error(err, err.stack));
 };
 
 const putInCache = async (request, response) => {
   const cache = await caches.open('v1');
-  await cache.put(request, response);
+  cache.put(request, response).catch(err => console.error(err, err.stack));
 };
 
 const cacheFirst = async ({ request, preloadResponsePromise, fallbackUrl }) => {


### PR DESCRIPTION
Pretty simple stuff, minimal code changed.  `await` as the last command in a function is pointless.  Errors thrown during the completion of a promise should be handled.  Low probability of errors in this project as-is, but high probability of errors for any newbie adapting this example for their own project.