### PR TITLE
fix(css): Make example a little more accessible

### DIFF
--- a/web-workers/simple-shared-worker/style.css
+++ b/web-workers/simple-shared-worker/style.css
@@ -1,15 +1,6 @@
 html {
-  background-color: #7d2663;
+  background-color: rgb(230, 230, 230);
   font-family: sans-serif;
-}
-
-h1 {
-  margin: 0;
-  font-size: 15vw;
-  letter-spacing: -0.2rem;
-  position: absolute;
-  top: 0;
-  z-index: -1;
 }
 
 p {
@@ -20,15 +11,8 @@ p {
   padding: 4vw;
   width: 75%;
   margin: 3vw auto;
-  background-color: rgba(255, 255, 255, 0.7);
-  border: 5px solid black;
-  opacity: 0.3;
-  transition: 1s all;
-}
-
-.controls:hover,
-.controls:focus {
-  opacity: 1;
+  border: 2px solid;
+  border-radius: 6px;
 }
 
 .controls label,

--- a/web-workers/simple-web-worker/style.css
+++ b/web-workers/simple-web-worker/style.css
@@ -1,40 +1,26 @@
 html {
-	background-color: #7D2663;
-	font-family: sans-serif;
-}
-
-h1 {
-	margin: 0;
-	font-size: 20vmin;
-	letter-spacing: -0.2rem;
-	position: absolute;
-	top: 0;
-	z-index: -1;
+  background-color: rgb(230, 230, 230);
+  font-family: sans-serif;
 }
 
 p {
-	margin: 0;
+  margin: 0 0 1rem 0;
 }
 
 .controls {
-	padding: 4vw;
-	width: 75%;
-	margin: 10vw auto;
-	background-color: rgba(255,255,255,0.7);
-	border: 5px solid black;
-	opacity: 0.3;
-	transition: 1s all;
+  padding: 4vw;
+  width: 75%;
+  margin: 3vw auto;
+  border: 2px solid;
+  border-radius: 6px;
 }
 
-.controls:hover, .controls:focus {
-  opacity: 1;
-}
-
-.controls label, .controls p, .controls input {
-	font-size: 3vw;
+.controls label,
+.controls p,
+.controls input {
+  font-size: 3vw;
 }
 
 .controls div {
   padding-bottom: 1rem;
 }
-


### PR DESCRIPTION
I'm removing a few of the fancier CSS things here, but the result is that we have a more accessible example, so the text foreground v background has good color contrast.

## Related issues and pull requests

Fixes #222 