### PR TITLE
fix(html): Make script elements children of head or body elements

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://html-validate.org/schemas/config.json",
-  "extends": ["html-validate:recommended", "html-validate:prettier"]
-}

--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://html-validate.org/schemas/config.json",
+  "extends": ["html-validate:recommended", "html-validate:prettier"]
+}

--- a/abort-api/index.html
+++ b/abort-api/index.html
@@ -36,7 +36,7 @@
       <p>Sintel © copyright Blender Foundation | <a href="http://www.sintel.org/">www.sintel.org</a>.</p>
     </div>
   </div>
-</body>
+
 <script>
   const url = 'sintel.mp4';
 
@@ -104,5 +104,5 @@
   }
 
 </script>
-
+</body>
 </html>

--- a/audiocontext-setsinkid/index.html
+++ b/audiocontext-setsinkid/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -14,27 +13,22 @@
     <script src="app.js" defer></script>
   </head>
   <body>
-    <h1>
-      SetSinkId test example
-    </h1>
-    
-    <button class="media-devices">
-      Get media devices
-    </button>
-    
-    <div class="select-container">
-      
-    </div>
-    
-    <button class="play">
-      Play audio
-    </button>
-    
+    <h1>SetSinkId test example</h1>
+
+    <button class="media-devices">Get media devices</button>
+
+    <div class="select-container"></div>
+
+    <button class="play">Play audio</button>
+
     <footer>
       <p>
-        Check out the <a href="https://github.com/mdn/dom-examples/tree/main/audiocontext-setsinkid">source code</a>.
+        Check out the
+        <a
+          href="https://github.com/mdn/dom-examples/tree/main/audiocontext-setsinkid"
+          >source code</a
+        >.
       </p>
     </footer>
-    
   </body>
 </html>

--- a/drag-and-drop/DnD-support.html
+++ b/drag-and-drop/DnD-support.html
@@ -1,152 +1,177 @@
 <!DOCTYPE html>
-<html lang=en>
-<title>Feature tests for DnD interfaces</title>
-<meta name="viewport" content="width=device-width">
-<style>
-  div {
-    margin: 0em;
-    padding: 2em;
-  }
-  #source {
-    color: blue;
-    border: 1px solid black;
-  }
-  #target {
-    border: 1px solid black;
-  }
-</style>
-<script>
-function check_DragEvents() {
-  // Check for support of the Drag event types
-  var events = ["ondrag",
-    "ondragstart",
-    "ondragend",
-    "ondragover",
-    "ondragenter",
-    "ondragleave",
-    "ondragexit",
-    "ondrop"];
+<html lang="en">
+  <head>
+    <title>Feature tests for DnD interfaces</title>
+    <meta name="viewport" content="width=device-width" />
+    <style>
+      div {
+        margin: 0em;
+        padding: 2em;
+      }
+      #source {
+        color: blue;
+        border: 1px solid black;
+      }
+      #target {
+        border: 1px solid black;
+      }
+    </style>
+    <script>
+      function check_DragEvents() {
+        // Check for support of the Drag event types
+        var events = [
+          "ondrag",
+          "ondragstart",
+          "ondragend",
+          "ondragover",
+          "ondragenter",
+          "ondragleave",
+          "ondragexit",
+          "ondrop",
+        ];
 
-  console.log("Drag Event Types...");
-  
-  for (var i=0; i < events.length; i++) {
-    var supported = events[i] in window;
-    console.log("... " + events[i] + " = " + (supported ? "Yes" : "No"));
-  }
-}
-function check_DataTransfer(dt) {
-  // Check the DataTransfer object's methods and properties
-  var properties = ["dropEffect",
-    "effectAllowed",
-    "types",
-    "files",
-    "items"];
-  var methods = ["setDragImage",
-    "getData",
-    "setData",
-    "clearData"];
+        console.log("Drag Event Types...");
 
-  console.log("DataTransfer ... " + dt);
-  
-  for (var i=0; i < properties.length; i++) {
-    var supported = properties[i] in dt;
-    console.log("... dataTransfer." + properties[i] + " = " + (supported ? "Yes" : "No"));
-  }
-  for (var i=0; i < methods.length; i++) {
-    var supported = typeof dt[methods[i]] == "function";
-    console.log("... dataTransfer." + methods[i] + "() = " + (supported ? "Yes" : "No"));
-  }
-}
-function check_DataTransferItem(dti) {
-  // Check the DataTransferItem object's methods and properties
-  var properties = ["kind",
-    "type"];
-  var methods = ["getAsFile",
-    "getAsString"];
+        for (var i = 0; i < events.length; i++) {
+          var supported = events[i] in window;
+          console.log("... " + events[i] + " = " + (supported ? "Yes" : "No"));
+        }
+      }
+      function check_DataTransfer(dt) {
+        // Check the DataTransfer object's methods and properties
+        var properties = [
+          "dropEffect",
+          "effectAllowed",
+          "types",
+          "files",
+          "items",
+        ];
+        var methods = ["setDragImage", "getData", "setData", "clearData"];
 
-  console.log("DataTransferItem ... " + dti);
+        console.log("DataTransfer ... " + dt);
 
-  for (var i=0; i < properties.length; i++) {
-    if (dti === undefined) {
-      console.log("... items." + properties[i] + " = undefined");
-    } else {
-      var supported = properties[i] in dti;
-      console.log("... items." + properties[i] + " = " + (supported ? "Yes" : "No"));
-    }
-  }
-  for (var i=0; i < methods.length; i++) {
-    if (dti === undefined) {
-      console.log("... items." + methods[i] + "() = undefined");
-    } else {
-      var supported = typeof dti[methods[i]] == "function";
-      console.log("... items." + methods[i] + "() = " + (supported ? "Yes" : "No"));
-    }
-  }
-}
-function check_DataTransferItemList(dtil) {
-  // Check the DataTransferItemList object's methods and properties
-  var properties = ["length"];
-  var methods = ["add",
-    "remove",
-    "clear"];
+        for (var i = 0; i < properties.length; i++) {
+          var supported = properties[i] in dt;
+          console.log(
+            "... dataTransfer." +
+              properties[i] +
+              " = " +
+              (supported ? "Yes" : "No")
+          );
+        }
+        for (var i = 0; i < methods.length; i++) {
+          var supported = typeof dt[methods[i]] == "function";
+          console.log(
+            "... dataTransfer." +
+              methods[i] +
+              "() = " +
+              (supported ? "Yes" : "No")
+          );
+        }
+      }
+      function check_DataTransferItem(dti) {
+        // Check the DataTransferItem object's methods and properties
+        var properties = ["kind", "type"];
+        var methods = ["getAsFile", "getAsString"];
 
-  console.log("DataTransferItemList ... " + dtil);
+        console.log("DataTransferItem ... " + dti);
 
-  for (var i=0; i < properties.length; i++) {
-    if (dtil === undefined) {
-      console.log("... items." + properties[i] + " = undefined");
-    } else {
-      var supported = properties[i] in dtil;
-      console.log("... items." + properties[i] + " = " + (supported ? "Yes" : "No"));
-    }
-  }
-  for (var i=0; i < methods.length; i++) {
-    if (dtil === undefined) {
-      console.log("... items." + methods[i] + "() = undefined");
-    } else {
-      var supported = typeof dtil[methods[i]] == "function";
-      console.log("... items." + methods[i] + "() = " + (supported ? "Yes" : "No"));
-    }
-  }
-}
-function dragstart_handler(ev) {
-  ev.dataTransfer.dropEffect = "move";
-  check_DragEvents();
-  var dt = ev.dataTransfer;
-  if (dt === undefined) {
-    console.log("DataTransfer is NOT supported."); 
-  } else {
-    // Make sure there is at least one item
-    dt.setData("text/plain", "Move this.");
-    check_DataTransfer(dt);
-  }
-}
-function dragover_handler(ev) {
-  ev.dataTransfer.dropEffect = "move";
-  ev.preventDefault();
-}
-function drop_handler(ev) {
-  if (ev.dataTransfer === undefined) {
-    console.log("DataTransferItem NOT supported."); 
-    console.log("DataTransferItemList NOT supported."); 
-  } else {
-    var dti = ev.dataTransfer.items;
-    if (dti === undefined) {
-      console.log("DataTransferItem NOT supported."); 
-      console.log("DataTransferItemList NOT supported."); 
-    } else {
-      check_DataTransferItem(dti[0]);
-      check_DataTransferItemList(dti);
-    }
-  }
-}
-</script>
-<body>
-<h1>Log support of DnD objects' methods and properties</h1>
- <div>
-   <p id="source" ondragstart="dragstart_handler(event);" draggable="true">
-     Select this element, drag it to the Drop Zone and then release the mouse. The console log will contain data about the DnD interfaces supported.</p>
- </div>
- <div id="target" ondrop="drop_handler(event);" ondragover="dragover_handler(event);">Drop Zone</div>
-</body>
+        for (var i = 0; i < properties.length; i++) {
+          if (dti === undefined) {
+            console.log("... items." + properties[i] + " = undefined");
+          } else {
+            var supported = properties[i] in dti;
+            console.log(
+              "... items." + properties[i] + " = " + (supported ? "Yes" : "No")
+            );
+          }
+        }
+        for (var i = 0; i < methods.length; i++) {
+          if (dti === undefined) {
+            console.log("... items." + methods[i] + "() = undefined");
+          } else {
+            var supported = typeof dti[methods[i]] == "function";
+            console.log(
+              "... items." + methods[i] + "() = " + (supported ? "Yes" : "No")
+            );
+          }
+        }
+      }
+      function check_DataTransferItemList(dtil) {
+        // Check the DataTransferItemList object's methods and properties
+        var properties = ["length"];
+        var methods = ["add", "remove", "clear"];
+
+        console.log("DataTransferItemList ... " + dtil);
+
+        for (var i = 0; i < properties.length; i++) {
+          if (dtil === undefined) {
+            console.log("... items." + properties[i] + " = undefined");
+          } else {
+            var supported = properties[i] in dtil;
+            console.log(
+              "... items." + properties[i] + " = " + (supported ? "Yes" : "No")
+            );
+          }
+        }
+        for (var i = 0; i < methods.length; i++) {
+          if (dtil === undefined) {
+            console.log("... items." + methods[i] + "() = undefined");
+          } else {
+            var supported = typeof dtil[methods[i]] == "function";
+            console.log(
+              "... items." + methods[i] + "() = " + (supported ? "Yes" : "No")
+            );
+          }
+        }
+      }
+      function dragstart_handler(ev) {
+        ev.dataTransfer.dropEffect = "move";
+        check_DragEvents();
+        var dt = ev.dataTransfer;
+        if (dt === undefined) {
+          console.log("DataTransfer is NOT supported.");
+        } else {
+          // Make sure there is at least one item
+          dt.setData("text/plain", "Move this.");
+          check_DataTransfer(dt);
+        }
+      }
+      function dragover_handler(ev) {
+        ev.dataTransfer.dropEffect = "move";
+        ev.preventDefault();
+      }
+      function drop_handler(ev) {
+        if (ev.dataTransfer === undefined) {
+          console.log("DataTransferItem NOT supported.");
+          console.log("DataTransferItemList NOT supported.");
+        } else {
+          var dti = ev.dataTransfer.items;
+          if (dti === undefined) {
+            console.log("DataTransferItem NOT supported.");
+            console.log("DataTransferItemList NOT supported.");
+          } else {
+            check_DataTransferItem(dti[0]);
+            check_DataTransferItemList(dti);
+          }
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Log support of DnD objects' methods and properties</h1>
+    <div>
+      <p id="source" ondragstart="dragstart_handler(event);" draggable="true">
+        Select this element, drag it to the Drop Zone and then release the
+        mouse. The console log will contain data about the DnD interfaces
+        supported.
+      </p>
+    </div>
+    <div
+      id="target"
+      ondrop="drop_handler(event);"
+      ondragover="dragover_handler(event);">
+      Drop Zone
+    </div>
+  </body>
 </html>

--- a/fetch/basic-fetch/index.html
+++ b/fetch/basic-fetch/index.html
@@ -14,25 +14,26 @@
     <h1>Fetch basic example</h1>
 
     <img src="" class="my-image" />
-  </body>
-  <script>
-    const myImage = document.querySelector(".my-image");
 
-    fetch("flowers.jpg")
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error, status = ${response.status}`);
-        }
-        return response.blob();
-      })
-      .then((myBlob) => {
-        const objectURL = URL.createObjectURL(myBlob);
-        myImage.src = objectURL;
-      })
-      .catch((error) => {
-        const p = document.createElement("p");
-        p.appendChild(document.createTextNode(`Error: ${error.message}`));
-        document.body.insertBefore(p, myImage);
-      });
-  </script>
+    <script>
+      const myImage = document.querySelector(".my-image");
+
+      fetch("flowers.jpg")
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP error, status = ${response.status}`);
+          }
+          return response.blob();
+        })
+        .then((myBlob) => {
+          const objectURL = URL.createObjectURL(myBlob);
+          myImage.src = objectURL;
+        })
+        .catch((error) => {
+          const p = document.createElement("p");
+          p.appendChild(document.createTextNode(`Error: ${error.message}`));
+          document.body.insertBefore(p, myImage);
+        });
+    </script>
+  </body>
 </html>

--- a/fetch/fetch-array-buffer/index.html
+++ b/fetch/fetch-array-buffer/index.html
@@ -18,55 +18,58 @@
     <span class="error"></span>
 
     <pre></pre>
+
+    <script>
+      const pre = document.querySelector("pre");
+      const myScript = document.querySelector("script");
+      const play = document.querySelector(".play");
+      const stop = document.querySelector(".stop");
+      const errorDisplay = document.querySelector(".error");
+
+      // use fetch to load an audio track, and
+      // decodeAudioData to decode it and stick it in a buffer.
+      // Then we put the buffer into the source
+      function getData() {
+        const audioCtx = new AudioContext();
+
+        return fetch("viper.ogg")
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`HTTP error, status = ${response.status}`);
+            }
+            return response.arrayBuffer();
+          })
+          .then((buffer) => audioCtx.decodeAudioData(buffer))
+          .then((decodedData) => {
+            const source = new AudioBufferSourceNode(audioCtx);
+            source.buffer = decodedData;
+            source.connect(audioCtx.destination);
+            return source;
+          });
+      }
+
+      // wire up buttons to stop and play audio
+      play.onclick = () => {
+        getData()
+          .then((source) => {
+            errorDisplay.innerHTML = "";
+            source.start(0);
+            play.disabled = true;
+          })
+          .catch((error) => {
+            errorDisplay.appendChild(
+              document.createTextNode(`Error: ${error.message}`)
+            );
+          });
+      };
+
+      stop.onclick = () => {
+        source.stop(0);
+        play.disabled = false;
+      };
+
+      // dump script to pre element
+      pre.innerHTML = myScript.innerHTML;
+    </script>
   </body>
-  <script>
-    const pre = document.querySelector("pre");
-    const myScript = document.querySelector("script");
-    const play = document.querySelector(".play");
-    const stop = document.querySelector(".stop");
-    const errorDisplay = document.querySelector(".error");
-
-    // use fetch to load an audio track, and
-    // decodeAudioData to decode it and stick it in a buffer.
-    // Then we put the buffer into the source
-    function getData() {
-      const audioCtx = new AudioContext();
-
-      return fetch("viper.ogg")
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(`HTTP error, status = ${response.status}`);
-          }
-          return response.arrayBuffer();
-        })
-        .then((buffer) => audioCtx.decodeAudioData(buffer))
-        .then((decodedData) => {
-          const source = new AudioBufferSourceNode(audioCtx);
-          source.buffer = decodedData;
-          source.connect(audioCtx.destination);
-          return source;
-        });
-    }
-
-    // wire up buttons to stop and play audio
-    play.onclick = () => {
-      getData()
-        .then((source) => {
-          errorDisplay.innerHTML = "";
-          source.start(0);
-          play.disabled = true;
-        })
-        .catch((error) => {
-          errorDisplay.appendChild(document.createTextNode(`Error: ${error.message}`));
-        });
-    };
-
-    stop.onclick = () => {
-      source.stop(0);
-      play.disabled = false;
-    };
-
-    // dump script to pre element
-    pre.innerHTML = myScript.innerHTML;
-  </script>
 </html>

--- a/fetch/fetch-json/index.html
+++ b/fetch/fetch-json/index.html
@@ -13,39 +13,40 @@
   <body>
     <h1>Fetch json example</h1>
     <ul></ul>
+
+    <script>
+      const myList = document.querySelector("ul");
+
+      fetch("products.json")
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP error, status = ${response.status}`);
+          }
+          return response.json();
+        })
+        .then((data) => {
+          for (const product of data.products) {
+            const listItem = document.createElement("li");
+
+            const nameElement = document.createElement("strong");
+            nameElement.textContent = product.Name;
+
+            const priceElement = document.createElement("strong");
+            priceElement.textContent = `£${product.Price}`;
+
+            listItem.append(
+              nameElement,
+              ` can be found in ${product.Location}. Cost: `,
+              priceElement
+            );
+            myList.appendChild(listItem);
+          }
+        })
+        .catch((error) => {
+          const p = document.createElement("p");
+          p.appendChild(document.createTextNode(`Error: ${error.message}`));
+          document.body.insertBefore(p, myList);
+        });
+    </script>
   </body>
-  <script>
-    const myList = document.querySelector("ul");
-
-    fetch("products.json")
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error, status = ${response.status}`);
-        }
-        return response.json();
-      })
-      .then((data) => {
-        for (const product of data.products) {
-          const listItem = document.createElement("li");
-          
-          const nameElement = document.createElement("strong");
-          nameElement.textContent = product.Name;
-          
-          const priceElement = document.createElement("strong");
-          priceElement.textContent = `£${product.Price}`;
-
-          listItem.append(
-            nameElement,
-            ` can be found in ${product.Location}. Cost: `,
-            priceElement,
-          );
-          myList.appendChild(listItem);
-        }
-      })
-      .catch((error) => {
-        const p = document.createElement("p");
-        p.appendChild(document.createTextNode(`Error: ${error.message}`));
-        document.body.insertBefore(p, myList);
-      });
-  </script>
 </html>

--- a/fetch/fetch-request-with-init/index.html
+++ b/fetch/fetch-request-with-init/index.html
@@ -13,36 +13,37 @@
   <body>
     <h1>Fetch Request with init example</h1>
     <img src="" />
+
+    <script>
+      const myImage = document.querySelector("img");
+
+      const myHeaders = new Headers();
+
+      const myOptions = {
+        method: "GET",
+        headers: myHeaders,
+        mode: "cors",
+        cache: "default",
+      };
+
+      const myRequest = new Request("flowers.jpg", myOptions);
+
+      fetch(myRequest)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP error, status = ${response.status}`);
+          }
+          return response.blob();
+        })
+        .then((blob) => {
+          const objectURL = URL.createObjectURL(blob);
+          myImage.src = objectURL;
+        })
+        .catch((error) => {
+          const p = document.createElement("p");
+          p.appendChild(document.createTextNode(`Error: ${error.message}`));
+          document.body.insertBefore(p, myImage);
+        });
+    </script>
   </body>
-  <script>
-    const myImage = document.querySelector("img");
-
-    const myHeaders = new Headers();
-
-    const myOptions = {
-      method: "GET",
-      headers: myHeaders,
-      mode: "cors",
-      cache: "default",
-    };
-
-    const myRequest = new Request("flowers.jpg", myOptions);
-
-    fetch(myRequest)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error, status = ${response.status}`);
-        }
-        return response.blob();
-      })
-      .then((blob) => {
-        const objectURL = URL.createObjectURL(blob);
-        myImage.src = objectURL;
-      })
-      .catch((error) => {
-        const p = document.createElement("p");
-        p.appendChild(document.createTextNode(`Error: ${error.message}`));
-        document.body.insertBefore(p, myImage);
-      });
-  </script>
 </html>

--- a/fetch/fetch-request/index.html
+++ b/fetch/fetch-request/index.html
@@ -11,26 +11,27 @@
   <body>
     <h1>Fetch Request example</h1>
     <img src="" />
-  </body>
-  <script>
-    const myImage = document.querySelector("img");
-    const myRequest = new Request("flowers.jpg");
 
-    fetch(myRequest)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error, status = ${response.status}`);
-        }
-        return response.blob();
-      })
-      .then((myBlob) => {
-        const objectURL = URL.createObjectURL(myBlob);
-        myImage.src = objectURL;
-      })
-      .catch((error) => {
-        const p = document.createElement("p");
-        p.appendChild(document.createTextNode(`Error: ${error.message}`));
-        document.body.insertBefore(p, myImage);
-      });
-  </script>
+    <script>
+      const myImage = document.querySelector("img");
+      const myRequest = new Request("flowers.jpg");
+
+      fetch(myRequest)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP error, status = ${response.status}`);
+          }
+          return response.blob();
+        })
+        .then((myBlob) => {
+          const objectURL = URL.createObjectURL(myBlob);
+          myImage.src = objectURL;
+        })
+        .catch((error) => {
+          const p = document.createElement("p");
+          p.appendChild(document.createTextNode(`Error: ${error.message}`));
+          document.body.insertBefore(p, myImage);
+        });
+    </script>
+  </body>
 </html>

--- a/fetch/fetch-response-clone/index.html
+++ b/fetch/fetch-response-clone/index.html
@@ -21,33 +21,34 @@
     <h1>Fetch response clone example</h1>
     <img src="" class="img1" />
     <img src="" class="img2" />
-  </body>
-  <script>
-    const image1 = document.querySelector(".img1");
-    const image2 = document.querySelector(".img2");
 
-    fetch("flowers.jpg").then((response1) => {
-      if (!response1.ok) {
-        showError(image1, `HTTP error, status = ${response1.status}`);
-      } else {
-        const response2 = response1.clone();
-        useResponse(response1, image1);
-        useResponse(response2, image2);
+    <script>
+      const image1 = document.querySelector(".img1");
+      const image2 = document.querySelector(".img2");
+
+      fetch("flowers.jpg").then((response1) => {
+        if (!response1.ok) {
+          showError(image1, `HTTP error, status = ${response1.status}`);
+        } else {
+          const response2 = response1.clone();
+          useResponse(response1, image1);
+          useResponse(response2, image2);
+        }
+      });
+
+      function useResponse(response, image) {
+        response
+          .blob()
+          .then((myBlob) => {
+            const objectURL = URL.createObjectURL(myBlob);
+            image.src = objectURL;
+          })
+          .catch((error) => {
+            const p = document.createElement("p");
+            p.appendChild(document.createTextNode(`Error: ${error}`));
+            document.body.insertBefore(p, image);
+          });
       }
-    });
-
-    function useResponse(response, image) {
-      response
-        .blob()
-        .then((myBlob) => {
-          const objectURL = URL.createObjectURL(myBlob);
-          image.src = objectURL;
-        })
-        .catch((error) => {
-          const p = document.createElement("p");
-          p.appendChild(document.createTextNode(`Error: ${error}`));
-          document.body.insertBefore(p, image);
-        });
-    }
-  </script>
+    </script>
+  </body>
 </html>

--- a/fetch/fetch-response/index.html
+++ b/fetch/fetch-response/index.html
@@ -13,38 +13,39 @@
   <body>
     <h1>Fetch basic response example</h1>
     <img src="" />
+
+    <script>
+      const myImage = document.querySelector("img");
+
+      const myRequest = new Request("flowers.jpg");
+
+      fetch(myRequest)
+        .then((response) => {
+          console.log("response.type =", response.type);
+          console.log("response.url =", response.url);
+          console.log("response.userFinalURL =", response.useFinalURL);
+          console.log("response.status =", response.status);
+          console.log("response.ok =", response.ok);
+          console.log("response.statusText =", response.statusText);
+          console.log("response.headers =", response.headers);
+          if (!response.ok) {
+            throw new Error(`HTTP error, status = ${response.status}`);
+          }
+          return response.blob();
+        })
+        .then((myBlob) => {
+          const objectURL = URL.createObjectURL(myBlob);
+          myImage.src = objectURL;
+        })
+        .catch((error) => {
+          const p = document.createElement("p");
+          p.appendChild(document.createTextNode(`Error: ${error.message}`));
+          document.body.insertBefore(p, myImage);
+        });
+
+      const myBlob = new Blob();
+      const options = { status: 200, statusText: "SuperSmashingGreat!" };
+      const myResponse = new Response(myBlob, options);
+    </script>
   </body>
-  <script>
-    const myImage = document.querySelector("img");
-
-    const myRequest = new Request("flowers.jpg");
-
-    fetch(myRequest)
-      .then((response) => {
-        console.log('response.type =', response.type);
-        console.log('response.url =', response.url);
-        console.log('response.userFinalURL =', response.useFinalURL);
-        console.log('response.status =', response.status);
-        console.log('response.ok =', response.ok);
-        console.log('response.statusText =', response.statusText);
-        console.log('response.headers =', response.headers);
-        if (!response.ok) {
-          throw new Error(`HTTP error, status = ${response.status}`);
-        }
-        return response.blob();
-      })
-      .then((myBlob) => {
-        const objectURL = URL.createObjectURL(myBlob);
-        myImage.src = objectURL;
-      })
-      .catch((error) => {
-        const p = document.createElement("p");
-        p.appendChild(document.createTextNode(`Error: ${error.message}`));
-        document.body.insertBefore(p, myImage);
-      });
-
-    const myBlob = new Blob();
-    const options = { status: 200, statusText: "SuperSmashingGreat!" };
-    const myResponse = new Response(myBlob, options);
-  </script>
 </html>

--- a/fetch/fetch-text/index.html
+++ b/fetch/fetch-text/index.html
@@ -18,35 +18,36 @@
       <li><a data-page="page3">Page 3</a></li>
     </ul>
     <article></article>
+
+    <script>
+      const myArticle = document.querySelector("article");
+      const myLinks = document.querySelectorAll("ul a");
+      for (const link of myLinks) {
+        link.onclick = (e) => {
+          e.preventDefault();
+          const linkData = e.target.getAttribute("data-page");
+          getData(linkData);
+        };
+      }
+
+      function getData(pageId) {
+        console.log(pageId);
+        const myRequest = new Request(`${pageId}.txt`);
+
+        fetch(myRequest)
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`HTTP error, status = ${response.status}`);
+            }
+            return response.text();
+          })
+          .then((text) => {
+            myArticle.innerText = text;
+          })
+          .catch((error) => {
+            myArticle.innerText = `Error: ${error.message}`;
+          });
+      }
+    </script>
   </body>
-  <script>
-    const myArticle = document.querySelector("article");
-    const myLinks = document.querySelectorAll("ul a");
-    for (const link of myLinks) {
-      link.onclick = (e) => {
-        e.preventDefault();
-        const linkData = e.target.getAttribute("data-page");
-        getData(linkData);
-      };
-    }
-
-    function getData(pageId) {
-      console.log(pageId);
-      const myRequest = new Request(`${pageId}.txt`);
-
-      fetch(myRequest)
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(`HTTP error, status = ${response.status}`);
-          }
-          return response.text();
-        })
-        .then((text) => {
-          myArticle.innerText = text;
-        })
-        .catch((error) => {
-          myArticle.innerText = `Error: ${error.message}`;
-        });
-    }
-  </script>
 </html>

--- a/fetch/fetch-with-init-then-request/index.html
+++ b/fetch/fetch-with-init-then-request/index.html
@@ -13,7 +13,7 @@
   <body>
     <h1>Fetch with init then Request example</h1>
     <img src="" />
-  </body>
+
   <script>
     const myImage = document.querySelector("img");
 
@@ -46,4 +46,5 @@
         document.body.insertBefore(p, myImage);
       });
   </script>
+  </body>
 </html>

--- a/fetch/object-fit-gallery-fetch/index.html
+++ b/fetch/object-fit-gallery-fetch/index.html
@@ -36,6 +36,7 @@
       <img class="thumb" />
     </div>
     <img class="main" />
+
+    <script src="main.js"></script>
   </body>
-  <script src="main.js"></script>
 </html>

--- a/indexeddb-examples/idbcursor/index.html
+++ b/indexeddb-examples/idbcursor/index.html
@@ -18,7 +18,7 @@
     </button>
     <button class="update">Update "A farewell.." year</button>
     <button class="direction">Display albums upsidedown</button>
-  </body>
 
-  <script src="scripts/main.js"></script>
+    <script src="scripts/main.js"></script>
+  </body>
 </html>

--- a/indexeddb-examples/idbindex/index.html
+++ b/indexeddb-examples/idbindex/index.html
@@ -6,8 +6,7 @@
     <link
       href="http://fonts.googleapis.com/css?family=Arvo|Bevan"
       rel="stylesheet"
-      type="text/css"
-    />
+      type="text/css" />
     <link href="style/style.css" type="text/css" rel="stylesheet" />
   </head>
   <body>
@@ -32,7 +31,6 @@
     <p>
       Click/focus each table column heading to sort the data by that column.
     </p>
+    <script src="scripts/main.js"></script>
   </body>
-
-  <script src="scripts/main.js"></script>
 </html>

--- a/indexeddb-examples/idbkeyrange/index.html
+++ b/indexeddb-examples/idbkeyrange/index.html
@@ -88,7 +88,8 @@
 
       <button class="run">Run query</button>
     </form>
-  </body>
+
 
   <script src="scripts/main.js"></script>
+  </body>
 </html>

--- a/insert-adjacent/insertAdjacentElement.html
+++ b/insert-adjacent/insertAdjacentElement.html
@@ -1,99 +1,102 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>insertAdjacentElement() demo</title>
-  <style>
-    div {
-      width: 50px;
-      height: 50px;
-      margin: 3px;
-      border: 3px solid black;
-      display: inline-block;
-      background-color: red;
-    }
-  </style>
-</head>
-<body>
+  <head>
+    <title>insertAdjacentElement() demo</title>
+    <style>
+      div {
+        width: 50px;
+        height: 50px;
+        margin: 3px;
+        border: 3px solid black;
+        display: inline-block;
+        background-color: red;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      Click colored box to select it, then use the first two buttons below to
+      insert elements before and after your selection.
+    </p>
 
-<p>Click colored box to select it, then use the first two buttons below to insert elements before and after your selection.</p>
+    <section>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+    </section>
 
-<section>
-  <div></div><div></div><div></div><div></div>
-</section>
+    <button class="before">Insert before</button>
+    <button class="after">Insert after</button>
+    <button class="reset">Reset demo</button>
 
-<button class="before">Insert before</button>
-<button class="after">Insert after</button>
-<button class="reset">Reset demo</button>
+    <script>
+      const beforeBtn = document.querySelector(".before");
+      const afterBtn = document.querySelector(".after");
+      const resetBtn = document.querySelector(".reset");
 
-</body>
+      const container = document.querySelector("section");
 
-<script>
-const beforeBtn = document.querySelector('.before');
-const afterBtn = document.querySelector('.after');
-const resetBtn = document.querySelector('.reset');
+      let activeElem;
 
-const container = document.querySelector('section');
+      resetBtn.addEventListener("click", () => {
+        while (container.firstChild) {
+          container.removeChild(container.firstChild);
+        }
 
-let activeElem;
+        for (let i = 0; i <= 3; i++) {
+          let tempDiv = document.createElement("div");
+          container.appendChild(tempDiv);
+          setListener(tempDiv);
+        }
+      });
 
-resetBtn.addEventListener('click', () => {
-  while (container.firstChild) {
-      container.removeChild(container.firstChild);
-  }
+      beforeBtn.addEventListener("click", function () {
+        let tempDiv = document.createElement("div");
+        tempDiv.style.backgroundColor = randomColor();
+        if (activeElem) {
+          activeElem.insertAdjacentElement("beforebegin", tempDiv);
+        }
+        setListener(tempDiv);
+      });
 
-  for (let i = 0; i <=3; i++) {
-    let tempDiv = document.createElement('div');
-    container.appendChild(tempDiv);
-    setListener(tempDiv);
-  }
-});
+      afterBtn.addEventListener("click", function () {
+        let tempDiv = document.createElement("div");
+        tempDiv.style.backgroundColor = randomColor();
+        if (activeElem) {
+          activeElem.insertAdjacentElement("afterend", tempDiv);
+        }
+        setListener(tempDiv);
+      });
 
-beforeBtn.addEventListener('click', function() {
-  let tempDiv = document.createElement('div');
-  tempDiv.style.backgroundColor = randomColor();
-  if (activeElem) {
-    activeElem.insertAdjacentElement('beforebegin',tempDiv);
-  }
-  setListener(tempDiv);
-});
+      function setListener(elem) {
+        elem.addEventListener("click", function () {
+          const allElems = document.querySelectorAll("section div");
+          for (let i = 0; i < allElems.length; i++) {
+            allElems[i].style.border = "3px solid black";
+          }
+          elem.style.border = "3px solid aqua";
+          activeElem = elem;
+        });
+      }
 
-afterBtn.addEventListener('click', function() {
-  let tempDiv = document.createElement('div');
-  tempDiv.style.backgroundColor = randomColor();
-  if (activeElem) {
-    activeElem.insertAdjacentElement('afterend',tempDiv);
-  }
-  setListener(tempDiv);
-});
+      function randomColor() {
+        function random() {
+          const result = Math.floor(Math.random() * 255);
+          return result;
+        }
 
-function setListener(elem) {
-  elem.addEventListener('click', function() {
-    const allElems = document.querySelectorAll('section div');
-      for (let i = 0; i < allElems.length; i++) {
-          allElems[i].style.border = '3px solid black';
-      } 
-    elem.style.border = '3px solid aqua';
-    activeElem = elem;
-  })
-};
+        return "rgb(" + random() + "," + random() + "," + random() + ")";
+      }
 
-function randomColor() {
-  function random() {
-    const result = Math.floor(Math.random() * 255);
-    return result;
-  }
+      function init() {
+        const initElems = document.querySelectorAll("section div");
+        for (let i = 0; i < initElems.length; i++) {
+          setListener(initElems[i]);
+        }
+      }
 
-  return 'rgb(' + random() + ',' + random() + ',' + random() + ')';
-}
-
-function init() {
-  const initElems = document.querySelectorAll('section div');
-  for (let i = 0; i < initElems.length; i++) {
-    setListener(initElems[i]);
-  }
-};
-
-init();
-</script>
-
+      init();
+    </script>
+  </body>
 </html>

--- a/insert-adjacent/insertAdjacentText.html
+++ b/insert-adjacent/insertAdjacentText.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>insertAdjacentText() demo</title>

--- a/insert-adjacent/insertAdjacentText.html
+++ b/insert-adjacent/insertAdjacentText.html
@@ -1,57 +1,55 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
 <html lang="en">
-<head>
-  <title>insertAdjacentText() demo</title>
-  <style>
-    section p {
-      font-size: 1.1rem;
-      color: blue;
-    }
+  <head>
+    <title>insertAdjacentText() demo</title>
+    <style>
+      section p {
+        font-size: 1.1rem;
+        color: blue;
+      }
 
-    input {
-      margin-bottom: 0.5rem;
-    }
-  </style>
-</head>
-<body>
+      input {
+        margin-bottom: 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      Enter some text to add, then use the first two buttons below to insert
+      your text after the existing text.
+    </p>
 
-<p>Enter some text to add, then use the first two buttons below to insert your text after the existing text.</p>
+    <section>
+      <p>This is my text</p>
+    </section>
 
-<section>
-  <p>This is my text</p>
-</section>
+    <input type="text" /><br />
+    <button class="before">Insert before</button>
+    <button class="after">Insert after</button>
+    <button class="reset">Reset demo</button>
 
-<input type="text"><br>
-<button class="before">Insert before</button>
-<button class="after">Insert after</button>
-<button class="reset">Reset demo</button>
+    <script>
+      var beforeBtn = document.querySelector(".before");
+      var afterBtn = document.querySelector(".after");
+      var resetBtn = document.querySelector(".reset");
 
-</body>
+      var para = document.querySelector("section p");
+      var initContent = para.textContent;
 
-<script>
+      var textInput = document.querySelector("input");
 
-  var beforeBtn = document.querySelector('.before');
-  var afterBtn = document.querySelector('.after');
-  var resetBtn = document.querySelector('.reset');
+      resetBtn.addEventListener("click", function () {
+        para.textContent = initContent;
+        textInput.value = "";
+      });
 
-  var para = document.querySelector('section p');
-  var initContent = para.textContent;
+      beforeBtn.addEventListener("click", function () {
+        para.insertAdjacentText("afterbegin", textInput.value);
+      });
 
-  var textInput = document.querySelector('input');
-
-  resetBtn.addEventListener('click', function() {
-    para.textContent = initContent;
-    textInput.value = '';
-  });
-
-  beforeBtn.addEventListener('click', function() {
-    para.insertAdjacentText('afterbegin',textInput.value);
-  });
-
-  afterBtn.addEventListener('click', function() {
-    para.insertAdjacentText('beforeend',textInput.value);
-  });
-
-</script>
-
+      afterBtn.addEventListener("click", function () {
+        para.insertAdjacentText("beforeend", textInput.value);
+      });
+    </script>
+  </body>
 </html>

--- a/matchmedia/index.html
+++ b/matchmedia/index.html
@@ -1,60 +1,59 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
 <html lang="en">
-<head>
-  <title>matchMedia test file</title>
-  <style>
+  <head>
+    <title>matchMedia test file</title>
+    <style>
+      html {
+        font-family: sans-serif;
+        background-color: white;
+      }
 
-    html {
-      font-family: sans-serif;
-      background-color: white;
-    }
+      body {
+        padding: 20px;
+        margin: 10px;
+        background-color: blue;
+        border: 10px solid black;
+      }
 
-    body {
-      padding: 20px;
-      margin: 10px;
-      background-color: blue;
-      border: 10px solid black;
-    }
+      h1,
+      p {
+        text-align: center;
+      }
 
-    h1, p {
-      text-align: center;
-    }
+      p {
+        font-size: 1.3rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>matchMedia test</h1>
 
-    p {
-      font-size: 1.3rem;
-    }
+    <p></p>
 
-  </style>
-</head>
-<body>
-  <h1>matchMedia test</h1>
+    <script>
+      var para = document.querySelector("p");
+      function screenTest() {
+        if (window.matchMedia("(max-width: 600px)").matches) {
+          /* the viewport is 600 pixels wide or less */
+          para.textContent =
+            "This is a narrow screen; " + window.innerWidth + "px wide.";
+          document.body.style.backgroundColor = "red";
+        } else if (window.matchMedia("(min-width: 1400px)").matches) {
+          /* the viewport is more than than 1400 pixels wide */
+          para.textContent =
+            "This is a REALLY wide screen; " + window.innerWidth + "px wide.";
+          document.body.style.backgroundColor = "green";
+        } else {
+          /* the viewport is more than than 400 pixels wide */
+          para.textContent =
+            "This is a wide screen; " + window.innerWidth + "px wide.";
+          document.body.style.backgroundColor = "blue";
+        }
+      }
 
-  <p></p>
-    
+      screenTest();
 
-</body>
-
-<script>
-  var para = document.querySelector('p');
-  function screenTest() {
-    if (window.matchMedia('(max-width: 600px)').matches) {
-      /* the viewport is 600 pixels wide or less */
-      para.textContent = 'This is a narrow screen; ' + window.innerWidth + "px wide.";
-      document.body.style.backgroundColor = 'red';
-    } else if(window.matchMedia('(min-width: 1400px)').matches) {
-      /* the viewport is more than than 1400 pixels wide */
-      para.textContent = 'This is a REALLY wide screen; ' + window.innerWidth + "px wide.";
-      document.body.style.backgroundColor = 'green';
-    } else {
-      /* the viewport is more than than 400 pixels wide */
-      para.textContent = 'This is a wide screen; ' + window.innerWidth + "px wide.";
-      document.body.style.backgroundColor = 'blue';
-    }
-  }
-
-  screenTest();
-
-  document.body.onresize = screenTest;
-</script>
-
+      document.body.onresize = screenTest;
+    </script>
+  </body>
 </html>

--- a/matchmedia/index.html
+++ b/matchmedia/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>matchMedia test file</title>

--- a/mediaquerylist/index.html
+++ b/mediaquerylist/index.html
@@ -1,64 +1,60 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>MediaQueryList example</title>
-  <style>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MediaQueryList example</title>
+    <style>
+      html {
+        font-family: sans-serif;
+        background-color: white;
+      }
 
-    html {
-      font-family: sans-serif;
-      background-color: white;
-    }
+      body {
+        padding: 20px;
+        margin: 10px;
+        background-color: blue;
+        border: 10px solid black;
+      }
 
-    body {
-      padding: 20px;
-      margin: 10px;
-      background-color: blue;
-      border: 10px solid black;
-    }
+      h1,
+      p {
+        text-align: center;
+      }
 
-    h1, p {
-      text-align: center;
-    }
+      p {
+        font-size: 1.3rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>matchMedia test</h1>
 
-    p {
-      font-size: 1.3rem;
-    }
+    <p></p>
 
-  </style>
-</head>
-<body>
-  <h1>matchMedia test</h1>
+    <script>
+      var para = document.querySelector("p");
 
-  <p></p>
+      var mql = window.matchMedia("(max-width: 600px)");
 
+      function screenTest(e) {
+        if (e.matches) {
+          /* the viewport is 600 pixels wide or less */
+          para.textContent = "This is a narrow screen — less than 600px wide.";
+          document.body.style.backgroundColor = "red";
+        } else {
+          /* the viewport is more than 600 pixels wide */
+          para.textContent = "This is a wide screen — more than 600px wide.";
+          document.body.style.backgroundColor = "blue";
+        }
+      }
 
-</body>
+      screenTest(mql);
+      mql.addEventListener("change", screenTest, false);
 
-<script>
-  var para = document.querySelector('p');
-
-  var mql = window.matchMedia('(max-width: 600px)');
-
-  function screenTest(e) {
-    if (e.matches) {
-      /* the viewport is 600 pixels wide or less */
-      para.textContent = 'This is a narrow screen — less than 600px wide.';
-      document.body.style.backgroundColor = 'red';
-    } else {
-      /* the viewport is more than 600 pixels wide */
-      para.textContent = 'This is a wide screen — more than 600px wide.';
-      document.body.style.backgroundColor = 'blue';
-    }
-  }
-
-  screenTest(mql);
-  mql.addEventListener('change', screenTest, false);
-
-  mql.onchange = function() {
-    console.log(mql);
-  }
-</script>
-
+      mql.onchange = function () {
+        console.log(mql);
+      };
+    </script>
+  </body>
 </html>

--- a/pointerevents/Multi-touch_interaction.html
+++ b/pointerevents/Multi-touch_interaction.html
@@ -1,176 +1,186 @@
 <!DOCTYPE html>
-<html lang=en>
-<!--
+<html lang="en">
+  <!--
   This app demonstrates using Pointer Events (pointerdown, pointerup, 
   pointermove, pointercancel, etc.) for the following interactions:
    1. Single touch
    2. Two (simultaneous) touches
    3. More than two simultaneous touches
 -->
-<head>
-<title>Pointer Events multi-touch interaction</title>
-<meta name="viewport" content="width=device-width">
-<style>
-  div {
-    margin: 0em;
-    padding: 2em;
-  }
-  #target1 {
-    background: white;
-    border: 1px solid black;
-  }
-  #target2 {
-    background: white;
-    border: 1px solid black;
-  }
-  #target3 {
-    background: white;
-    border: 1px solid black;
-  }
-</style>
-</head>
+  <head>
+    <title>Pointer Events multi-touch interaction</title>
+    <meta name="viewport" content="width=device-width" />
+    <style>
+      div {
+        margin: 0em;
+        padding: 2em;
+      }
+      #target1 {
+        background: white;
+        border: 1px solid black;
+      }
+      #target2 {
+        background: white;
+        border: 1px solid black;
+      }
+      #target3 {
+        background: white;
+        border: 1px solid black;
+      }
+    </style>
 
-<script>
-// Log events flag
-var logEvents = false;
+    <script>
+      // Log events flag
+      var logEvents = false;
 
-// Event caches, one per touch target
-var evCache1 = new Array();
-var evCache2 = new Array();
-var evCache3 = new Array();
+      // Event caches, one per touch target
+      var evCache1 = new Array();
+      var evCache2 = new Array();
+      var evCache3 = new Array();
 
-function enableLog(ev) {
-  logEvents = logEvents ? false : true;
-}
+      function enableLog(ev) {
+        logEvents = logEvents ? false : true;
+      }
 
-function log(name, ev) {
-  var o = document.getElementsByTagName('output')[0];
-  var s = name + ": pointerID = " + ev.pointerId +
-                " ; pointerType = " + ev.pointerType +
-                " ; isPrimary = " + ev.isPrimary;
-  o.innerHTML += s + " <br>";
-} 
+      function log(name, ev) {
+        var o = document.getElementsByTagName("output")[0];
+        var s =
+          name +
+          ": pointerID = " +
+          ev.pointerId +
+          " ; pointerType = " +
+          ev.pointerType +
+          " ; isPrimary = " +
+          ev.isPrimary;
+        o.innerHTML += s + " <br>";
+      }
 
-function clearLog(event) {
- var o = document.getElementsByTagName('output')[0];
- o.innerHTML = "";
-}
+      function clearLog(event) {
+        var o = document.getElementsByTagName("output")[0];
+        o.innerHTML = "";
+      }
 
-function update_background(ev) {
- // Change background color based on the number simultaneous touches/pointers
- // currently down:
- //   white - target element has no touch points i.e. no pointers down
- //   yellow - one pointer down
- //   pink - two pointers down
- //   lightblue - three or more pointers down
- var evCache = get_cache(ev);
- switch (evCache.length) {
-   case 0:
-     // Target element has no touch points
-     ev.target.style.background = "white";
-     break;
-   case 1:
-     // Single touch point
-     ev.target.style.background = "yellow";
-     break;
-   case 2:
-     // Two simultaneous touch points
-     ev.target.style.background = "pink";
-     break;
-   default:
-     // Three or more simultaneous touches
-     ev.target.style.background = "lightblue";
- }
-}
+      function update_background(ev) {
+        // Change background color based on the number simultaneous touches/pointers
+        // currently down:
+        //   white - target element has no touch points i.e. no pointers down
+        //   yellow - one pointer down
+        //   pink - two pointers down
+        //   lightblue - three or more pointers down
+        var evCache = get_cache(ev);
+        switch (evCache.length) {
+          case 0:
+            // Target element has no touch points
+            ev.target.style.background = "white";
+            break;
+          case 1:
+            // Single touch point
+            ev.target.style.background = "yellow";
+            break;
+          case 2:
+            // Two simultaneous touch points
+            ev.target.style.background = "pink";
+            break;
+          default:
+            // Three or more simultaneous touches
+            ev.target.style.background = "lightblue";
+        }
+      }
 
-function pointerdown_handler(ev) {
- // The pointerdown event signals the start of a touch interaction.
- // Save this event for later processing (this could be part of a
- // multi-touch interaction) and update the background color
- push_event(ev);
- if (logEvents) log("pointerDown: name = " + ev.target.id, ev);
- update_background(ev);
-}
+      function pointerdown_handler(ev) {
+        // The pointerdown event signals the start of a touch interaction.
+        // Save this event for later processing (this could be part of a
+        // multi-touch interaction) and update the background color
+        push_event(ev);
+        if (logEvents) log("pointerDown: name = " + ev.target.id, ev);
+        update_background(ev);
+      }
 
-function pointermove_handler(ev) {
- // Note: if the user makes more than one "simultaneous" touch, most browsers 
- // fire at least one pointermove event and some will fire several pointermoves.
- //
- // This function sets the target element's border to "dashed" to visually
- // indicate the target received a move event.
- if (logEvents) log("pointerMove", ev);
- update_background(ev);
- ev.target.style.border = "dashed";
-}
+      function pointermove_handler(ev) {
+        // Note: if the user makes more than one "simultaneous" touch, most browsers
+        // fire at least one pointermove event and some will fire several pointermoves.
+        //
+        // This function sets the target element's border to "dashed" to visually
+        // indicate the target received a move event.
+        if (logEvents) log("pointerMove", ev);
+        update_background(ev);
+        ev.target.style.border = "dashed";
+      }
 
-function pointerup_handler(ev) {
-  if (logEvents) log(ev.type, ev);
-  // Remove this touch point from the cache and reset the target's
-  // background and border
-  remove_event(ev);
-  update_background(ev);
-  ev.target.style.border = "1px solid black";
-}
+      function pointerup_handler(ev) {
+        if (logEvents) log(ev.type, ev);
+        // Remove this touch point from the cache and reset the target's
+        // background and border
+        remove_event(ev);
+        update_background(ev);
+        ev.target.style.border = "1px solid black";
+      }
 
-function get_cache(ev) {
- // Return the cache for this event's target element
- switch(ev.target.id) {
-   case "target1": return evCache1;
-   case "target2": return evCache2;
-   case "target3": return evCache3;
-   default: log("Error with cache handling",ev);
- }
-}
+      function get_cache(ev) {
+        // Return the cache for this event's target element
+        switch (ev.target.id) {
+          case "target1":
+            return evCache1;
+          case "target2":
+            return evCache2;
+          case "target3":
+            return evCache3;
+          default:
+            log("Error with cache handling", ev);
+        }
+      }
 
-function push_event(ev) {
- // Save this event in the target's cache
- var cache = get_cache(ev);
- cache.push(ev);
-}
+      function push_event(ev) {
+        // Save this event in the target's cache
+        var cache = get_cache(ev);
+        cache.push(ev);
+      }
 
-function remove_event(ev) {
- // Remove this event from the target's cache
- var cache = get_cache(ev);
- for (var i = 0; i < cache.length; i++) {
-   if (cache[i].pointerId == ev.pointerId) {
-     cache.splice(i, 1);
-     break;
-   }
- }
-}
+      function remove_event(ev) {
+        // Remove this event from the target's cache
+        var cache = get_cache(ev);
+        for (var i = 0; i < cache.length; i++) {
+          if (cache[i].pointerId == ev.pointerId) {
+            cache.splice(i, 1);
+            break;
+          }
+        }
+      }
 
-function set_handlers(name) {
- // Install event handlers for the given element
- var el=document.getElementById(name);
- el.onpointerdown = pointerdown_handler;
- el.onpointermove = pointermove_handler;
+      function set_handlers(name) {
+        // Install event handlers for the given element
+        var el = document.getElementById(name);
+        el.onpointerdown = pointerdown_handler;
+        el.onpointermove = pointermove_handler;
 
- // Use same handler for pointer{up,cancel,out,leave} events since
- // the semantics for these events - in this app - are the same.
- el.onpointerup = pointerup_handler;
- el.onpointercancel = pointerup_handler;
- el.onpointerout = pointerup_handler;
- el.onpointerleave = pointerup_handler;
-}
+        // Use same handler for pointer{up,cancel,out,leave} events since
+        // the semantics for these events - in this app - are the same.
+        el.onpointerup = pointerup_handler;
+        el.onpointercancel = pointerup_handler;
+        el.onpointerout = pointerup_handler;
+        el.onpointerleave = pointerup_handler;
+      }
 
-function init() {
- set_handlers("target1");
- set_handlers("target2");
- set_handlers("target3");
-}
+      function init() {
+        set_handlers("target1");
+        set_handlers("target2");
+        set_handlers("target3");
+      }
+    </script>
+  </head>
+  <body onload="init();" style="touch-action: none">
+    <h1>Multi-touch interaction</h1>
+    <!-- Create some boxes to test various gestures. -->
+    <div id="target1">Tap, Hold or Swipe me 1</div>
+    <div id="target2">Tap, Hold or Swipe me 2</div>
+    <div id="target3">Tap, Hold or Swipe me 3</div>
 
-</script>
-<body onload="init();" style="touch-action:none">
-<h1>Multi-touch interaction</h1>
- <!-- Create some boxes to test various gestures. -->
- <div id="target1">Tap, Hold or Swipe me 1</div>
- <div id="target2">Tap, Hold or Swipe me 2</div>
- <div id="target3">Tap, Hold or Swipe me 3</div>
-
- <!-- UI for logging/bebugging -->
- <button id="log" onclick="enableLog(event);">Start/Stop event logging</button>
- <button id="clearlog" onclick="clearLog(event);">Clear the log</button>
- <p></p>
- <output></output>
-</body>
+    <!-- UI for logging/bebugging -->
+    <button id="log" onclick="enableLog(event);">
+      Start/Stop event logging
+    </button>
+    <button id="clearlog" onclick="clearLog(event);">Clear the log</button>
+    <p></p>
+    <output></output>
+  </body>
 </html>

--- a/pointerevents/Pinch_zoom_gestures.html
+++ b/pointerevents/Pinch_zoom_gestures.html
@@ -1,148 +1,159 @@
 <!DOCTYPE html>
-<html lang=en>
-<!--
+<html lang="en">
+  <!--
   This application demonstrates using Pointer Events for simple 2-pointer
   pinch/zoom gesture recognition.
 -->
-<head>
-<title>Pointer Events pinch/zoom example</title>
-<meta name="viewport" content="width=device-width">
-<style>
-  div {
-    margin: 0em;
-    padding: 2em;
-  }
-  #target {
-    background: white;
-    border: 1px solid black;
-  }
-</style>
-</head>
+  <head>
+    <title>Pointer Events pinch/zoom example</title>
+    <meta name="viewport" content="width=device-width" />
+    <style>
+      div {
+        margin: 0em;
+        padding: 2em;
+      }
+      #target {
+        background: white;
+        border: 1px solid black;
+      }
+    </style>
 
-<script>
-// Log events flag
-var logEvents = false;
+    <script>
+      // Log events flag
+      var logEvents = false;
 
-// Global vars to cache event state
-var evCache = new Array();
-var prevDiff = -1;
+      // Global vars to cache event state
+      var evCache = new Array();
+      var prevDiff = -1;
 
-// Logging/debugging functions
-function enableLog(ev) {
-  logEvents = logEvents ? false : true;
-}
+      // Logging/debugging functions
+      function enableLog(ev) {
+        logEvents = logEvents ? false : true;
+      }
 
-function log(prefix, ev) {
-  if (!logEvents) return;
-  var o = document.getElementsByTagName('output')[0];
-  var s = prefix + ": pointerID = " + ev.pointerId +
-                " ; pointerType = " + ev.pointerType +
-                " ; isPrimary = " + ev.isPrimary;
-  o.innerHTML += s + " <br>";
-} 
+      function log(prefix, ev) {
+        if (!logEvents) return;
+        var o = document.getElementsByTagName("output")[0];
+        var s =
+          prefix +
+          ": pointerID = " +
+          ev.pointerId +
+          " ; pointerType = " +
+          ev.pointerType +
+          " ; isPrimary = " +
+          ev.isPrimary;
+        o.innerHTML += s + " <br>";
+      }
 
-function clearLog(event) {
- var o = document.getElementsByTagName('output')[0];
- o.innerHTML = "";
-}
+      function clearLog(event) {
+        var o = document.getElementsByTagName("output")[0];
+        o.innerHTML = "";
+      }
 
-function pointerdown_handler(ev) {
- // The pointerdown event signals the start of a touch interaction.
- // This event is cached to support 2-finger gestures
- evCache.push(ev);
- log("pointerDown", ev);
-}
+      function pointerdown_handler(ev) {
+        // The pointerdown event signals the start of a touch interaction.
+        // This event is cached to support 2-finger gestures
+        evCache.push(ev);
+        log("pointerDown", ev);
+      }
 
-function pointermove_handler(ev) {
- // This function implements a 2-pointer horizontal pinch/zoom gesture. 
- //
- // If the distance between the two pointers has increased (zoom in), 
- // the taget element's background is changed to "pink" and if the 
- // distance is decreasing (zoom out), the color is changed to "lightblue".
- //
- // This function sets the target element's border to "dashed" to visually
- // indicate the pointer's target received a move event.
- log("pointerMove", ev);
- ev.target.style.border = "dashed";
+      function pointermove_handler(ev) {
+        // This function implements a 2-pointer horizontal pinch/zoom gesture.
+        //
+        // If the distance between the two pointers has increased (zoom in),
+        // the taget element's background is changed to "pink" and if the
+        // distance is decreasing (zoom out), the color is changed to "lightblue".
+        //
+        // This function sets the target element's border to "dashed" to visually
+        // indicate the pointer's target received a move event.
+        log("pointerMove", ev);
+        ev.target.style.border = "dashed";
 
- // Find this event in the cache and update its record with this event
- for (var i = 0; i < evCache.length; i++) {
-   if (ev.pointerId == evCache[i].pointerId) {
-      evCache[i] = ev;
-   break;
-   }
- }
+        // Find this event in the cache and update its record with this event
+        for (var i = 0; i < evCache.length; i++) {
+          if (ev.pointerId == evCache[i].pointerId) {
+            evCache[i] = ev;
+            break;
+          }
+        }
 
- // If two pointers are down, check for pinch gestures
- if (evCache.length == 2) {
-   // Calculate the distance between the two pointers
-   var curDiff = Math.sqrt(Math.pow(evCache[1].clientX - evCache[0].clientX, 2) + Math.pow(evCache[1].clientY - evCache[0].clientY, 2));
+        // If two pointers are down, check for pinch gestures
+        if (evCache.length == 2) {
+          // Calculate the distance between the two pointers
+          var curDiff = Math.sqrt(
+            Math.pow(evCache[1].clientX - evCache[0].clientX, 2) +
+              Math.pow(evCache[1].clientY - evCache[0].clientY, 2)
+          );
 
-   if (prevDiff > 0) {
-     if (curDiff > prevDiff) {
-       // The distance between the two pointers has increased
-       log("Pinch moving OUT -> Zoom in", ev);
-       ev.target.style.background = "pink";
-     }
-     if (curDiff < prevDiff) {
-       // The distance between the two pointers has decreased
-       log("Pinch moving IN -> Zoom out",ev);
-       ev.target.style.background = "lightblue";
-     }
-   }
+          if (prevDiff > 0) {
+            if (curDiff > prevDiff) {
+              // The distance between the two pointers has increased
+              log("Pinch moving OUT -> Zoom in", ev);
+              ev.target.style.background = "pink";
+            }
+            if (curDiff < prevDiff) {
+              // The distance between the two pointers has decreased
+              log("Pinch moving IN -> Zoom out", ev);
+              ev.target.style.background = "lightblue";
+            }
+          }
 
-   // Cache the distance for the next move event 
-   prevDiff = curDiff;
- }
-}
+          // Cache the distance for the next move event
+          prevDiff = curDiff;
+        }
+      }
 
-function pointerup_handler(ev) {
-  log(ev.type, ev);
-  // Remove this pointer from the cache and reset the target's
-  // background and border
-  remove_event(ev);
-  ev.target.style.background = "white";
-  ev.target.style.border = "1px solid black";
- 
-  // If the number of pointers down is less than two then reset diff tracker
-  if (evCache.length < 2) prevDiff = -1;
-}
+      function pointerup_handler(ev) {
+        log(ev.type, ev);
+        // Remove this pointer from the cache and reset the target's
+        // background and border
+        remove_event(ev);
+        ev.target.style.background = "white";
+        ev.target.style.border = "1px solid black";
 
-function remove_event(ev) {
- // Remove this event from the target's cache
- for (var i = 0; i < evCache.length; i++) {
-   if (evCache[i].pointerId == ev.pointerId) {
-     evCache.splice(i, 1);
-     break;
-   }
- }
-}
+        // If the number of pointers down is less than two then reset diff tracker
+        if (evCache.length < 2) prevDiff = -1;
+      }
 
-function init() {
- // Install event handlers for the pointer target
- var el=document.getElementById("target");
- el.onpointerdown = pointerdown_handler;
- el.onpointermove = pointermove_handler;
+      function remove_event(ev) {
+        // Remove this event from the target's cache
+        for (var i = 0; i < evCache.length; i++) {
+          if (evCache[i].pointerId == ev.pointerId) {
+            evCache.splice(i, 1);
+            break;
+          }
+        }
+      }
 
- // Use same handler for pointer{up,cancel,out,leave} events since
- // the semantics for these events - in this app - are the same.
- el.onpointerup = pointerup_handler;
- el.onpointercancel = pointerup_handler;
- el.onpointerout = pointerup_handler;
- el.onpointerleave = pointerup_handler;
-}
+      function init() {
+        // Install event handlers for the pointer target
+        var el = document.getElementById("target");
+        el.onpointerdown = pointerdown_handler;
+        el.onpointermove = pointermove_handler;
 
-</script>
-<body onload="init();" style="touch-action:none">
-<h1>Pointer Event pinch/zoom gesture</h1>
- <!-- Create element for pointer gestures. -->
- <div id="target">Touch and Hold with 2 pointers, then pinch in or out.<br/>
-    The background color will change to pink if the pinch is opening (Zoom In) 
-    or changes to lightblue if the pinch is closing (Zoom out).</div>
- <!-- UI for logging/debugging -->
- <button id="log" onclick="enableLog(event);">Start/Stop event logging</button>
- <button id="clearlog" onclick="clearLog(event);">Clear the log</button>
- <p></p>
- <output></output>
-</body>
+        // Use same handler for pointer{up,cancel,out,leave} events since
+        // the semantics for these events - in this app - are the same.
+        el.onpointerup = pointerup_handler;
+        el.onpointercancel = pointerup_handler;
+        el.onpointerout = pointerup_handler;
+        el.onpointerleave = pointerup_handler;
+      }
+    </script>
+  </head>
+  <body onload="init();" style="touch-action: none">
+    <h1>Pointer Event pinch/zoom gesture</h1>
+    <!-- Create element for pointer gestures. -->
+    <div id="target">
+      Touch and Hold with 2 pointers, then pinch in or out.<br />
+      The background color will change to pink if the pinch is opening (Zoom In)
+      or changes to lightblue if the pinch is closing (Zoom out).
+    </div>
+    <!-- UI for logging/debugging -->
+    <button id="log" onclick="enableLog(event);">
+      Start/Stop event logging
+    </button>
+    <button id="clearlog" onclick="clearLog(event);">Clear the log</button>
+    <p></p>
+    <output></output>
+  </body>
 </html>

--- a/touchevents/Multi-touch_interaction.html
+++ b/touchevents/Multi-touch_interaction.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html lang=en>
-<!--
+<html lang="en">
+  <!--
   This app demonstrates using the Touch Events touch event types (touchstart,
   touchmove, touchcancel and touchend) for the following interaction:
    1. Single touch
@@ -9,184 +9,198 @@
    4. 1-finger swipe
    5. 2-finger move/pinch/swipe
 -->
-<head>
-<title>Touch Events tutorial</title>
-<meta name="viewport" content="width=device-width">
-<style>
-  div {
-    margin: 0em;
-    padding: 2em;
-  }
-  
-  #target1, #target2, #target3, #target4  {
-    background: white;
-    border: 1px solid black;
-  }
-</style>
-</head>
+  <head>
+    <title>Touch Events tutorial</title>
+    <meta name="viewport" content="width=device-width" />
+    <style>
+      div {
+        margin: 0em;
+        padding: 2em;
+      }
 
-<script>
-// Log events flag
-var logEvents = false;
+      #target1,
+      #target2,
+      #target3,
+      #target4 {
+        background: white;
+        border: 1px solid black;
+      }
+    </style>
 
-// Touch Point cache
-var tpCache = new Array();
+    <script>
+      // Log events flag
+      var logEvents = false;
 
-function enableLog(ev) {
-  logEvents = logEvents ? false : true;
-}
+      // Touch Point cache
+      var tpCache = new Array();
 
-function log(name, ev, printTargetIds) {
-  var o = document.getElementsByTagName('output')[0];
-  var s = name + ": touches = " + ev.touches.length +
-                " ; targetTouches = " + ev.targetTouches.length +
-                " ; changedTouches = " + ev.changedTouches.length;
-  o.innerHTML += s + " <br>";
+      function enableLog(ev) {
+        logEvents = logEvents ? false : true;
+      }
 
-  if (printTargetIds) {
-    s = "";
-    for (var i=0; i < ev.targetTouches.length; i++) {
-      s += "... id = " + ev.targetTouches[i].identifier + " <br>";
-    }
-    o.innerHTML += s;
-  }
-}
+      function log(name, ev, printTargetIds) {
+        var o = document.getElementsByTagName("output")[0];
+        var s =
+          name +
+          ": touches = " +
+          ev.touches.length +
+          " ; targetTouches = " +
+          ev.targetTouches.length +
+          " ; changedTouches = " +
+          ev.changedTouches.length;
+        o.innerHTML += s + " <br>";
 
-function clearLog(event) {
- var o = document.getElementsByTagName('output')[0];
- o.innerHTML = "";
-}
+        if (printTargetIds) {
+          s = "";
+          for (var i = 0; i < ev.targetTouches.length; i++) {
+            s += "... id = " + ev.targetTouches[i].identifier + " <br>";
+          }
+          o.innerHTML += s;
+        }
+      }
 
-function update_background(ev) {
- // Change background color based on the number simultaneous touches
- // in the event's targetTouches list:
- //   yellow - one tap (or hold)
- //   pink - two taps
- //   lightblue - more than two taps
- switch (ev.targetTouches.length) {
-   case 1:
-     // Single tap`
-     ev.target.style.background = "yellow";
-     break;
-   case 2:
-     // Two simultaneous touches
-     ev.target.style.background = "pink";
-     break;
-   default:
-     // More than two simultaneous touches
-     ev.target.style.background = "lightblue";
- }
-}
+      function clearLog(event) {
+        var o = document.getElementsByTagName("output")[0];
+        o.innerHTML = "";
+      }
 
-// This is a very basic 2-touch move/pinch/zoom handler that does not include
-// error handling, only handles horizontal moves, etc.
-function handle_pinch_zoom(ev) {
+      function update_background(ev) {
+        // Change background color based on the number simultaneous touches
+        // in the event's targetTouches list:
+        //   yellow - one tap (or hold)
+        //   pink - two taps
+        //   lightblue - more than two taps
+        switch (ev.targetTouches.length) {
+          case 1:
+            // Single tap`
+            ev.target.style.background = "yellow";
+            break;
+          case 2:
+            // Two simultaneous touches
+            ev.target.style.background = "pink";
+            break;
+          default:
+            // More than two simultaneous touches
+            ev.target.style.background = "lightblue";
+        }
+      }
 
- if (ev.targetTouches.length == 2 && ev.changedTouches.length == 2) {
-   // Check if the two target touches are the same ones that started
-   // the 2-touch
-   var point1=-1, point2=-1;
-   for (var i=0; i < tpCache.length; i++) {
-     if (tpCache[i].identifier == ev.targetTouches[0].identifier) point1 = i;
-     if (tpCache[i].identifier == ev.targetTouches[1].identifier) point2 = i;
-   }
-   if (point1 >=0 && point2 >= 0) {
-     // Calculate the difference between the start and move coordinates
-     var diff1 = Math.abs(tpCache[point1].clientX - ev.targetTouches[0].clientX);
-     var diff2 = Math.abs(tpCache[point2].clientX - ev.targetTouches[1].clientX);
+      // This is a very basic 2-touch move/pinch/zoom handler that does not include
+      // error handling, only handles horizontal moves, etc.
+      function handle_pinch_zoom(ev) {
+        if (ev.targetTouches.length == 2 && ev.changedTouches.length == 2) {
+          // Check if the two target touches are the same ones that started
+          // the 2-touch
+          var point1 = -1,
+            point2 = -1;
+          for (var i = 0; i < tpCache.length; i++) {
+            if (tpCache[i].identifier == ev.targetTouches[0].identifier)
+              point1 = i;
+            if (tpCache[i].identifier == ev.targetTouches[1].identifier)
+              point2 = i;
+          }
+          if (point1 >= 0 && point2 >= 0) {
+            // Calculate the difference between the start and move coordinates
+            var diff1 = Math.abs(
+              tpCache[point1].clientX - ev.targetTouches[0].clientX
+            );
+            var diff2 = Math.abs(
+              tpCache[point2].clientX - ev.targetTouches[1].clientX
+            );
 
-     // This threshold is device dependent as well as application specific
-     var PINCH_THRESHHOLD = ev.target.clientWidth / 10;
-     if (diff1 >= PINCH_THRESHHOLD && diff2 >= PINCH_THRESHHOLD)
-         ev.target.style.background = "green";
-   }
-   else {
-     // empty tpCache
-     tpCache = new Array();
-   }
- }
-}
+            // This threshold is device dependent as well as application specific
+            var PINCH_THRESHHOLD = ev.target.clientWidth / 10;
+            if (diff1 >= PINCH_THRESHHOLD && diff2 >= PINCH_THRESHHOLD)
+              ev.target.style.background = "green";
+          } else {
+            // empty tpCache
+            tpCache = new Array();
+          }
+        }
+      }
 
-function start_handler(ev) {
- // If the user makes simultaneious touches, the browser will fire a
- // separate touchstart event for each touch point. Thus if there are
- // three simultaneous touches, the first touchstart event will have
- // targetTouches length of one, the second event will have a length
- // of two, and so on.
- ev.preventDefault();
- // Cache the touch points for later processing of 2-touch pinch/zoom
- if (ev.targetTouches.length == 2) {
-   for (var i=0; i < ev.targetTouches.length; i++) {
-     tpCache.push(ev.targetTouches[i]);
-   }
- }
- if (logEvents) log("touchStart", ev, true);
- update_background(ev);
-}
+      function start_handler(ev) {
+        // If the user makes simultaneious touches, the browser will fire a
+        // separate touchstart event for each touch point. Thus if there are
+        // three simultaneous touches, the first touchstart event will have
+        // targetTouches length of one, the second event will have a length
+        // of two, and so on.
+        ev.preventDefault();
+        // Cache the touch points for later processing of 2-touch pinch/zoom
+        if (ev.targetTouches.length == 2) {
+          for (var i = 0; i < ev.targetTouches.length; i++) {
+            tpCache.push(ev.targetTouches[i]);
+          }
+        }
+        if (logEvents) log("touchStart", ev, true);
+        update_background(ev);
+      }
 
-function move_handler(ev) {
- // Note: if the user makes more than one "simultaneous" touches, most browsers
- // fire at least one touchmove event and some will fire several touchmoves.
- // Consequently, an application might want to "ignore" some touchmoves.
- //
- // This function sets the target element's outline to "dashed" to visualy
- // indicate the target received a move event.
- //
- ev.preventDefault();
- if (logEvents) log("touchMove", ev, false);
- // To avoid too much color flashing many touchmove events are started,
- // don't update the background if two touch points are active
- if (!(ev.touches.length == 2 && ev.targetTouches.length == 2))
-   update_background(ev);
+      function move_handler(ev) {
+        // Note: if the user makes more than one "simultaneous" touches, most browsers
+        // fire at least one touchmove event and some will fire several touchmoves.
+        // Consequently, an application might want to "ignore" some touchmoves.
+        //
+        // This function sets the target element's outline to "dashed" to visualy
+        // indicate the target received a move event.
+        //
+        ev.preventDefault();
+        if (logEvents) log("touchMove", ev, false);
+        // To avoid too much color flashing many touchmove events are started,
+        // don't update the background if two touch points are active
+        if (!(ev.touches.length == 2 && ev.targetTouches.length == 2))
+          update_background(ev);
 
- // Set the target element's outline to dashed to give a clear visual
- // indication the element received a move event.
- ev.target.style.outline = "dashed";
+        // Set the target element's outline to dashed to give a clear visual
+        // indication the element received a move event.
+        ev.target.style.outline = "dashed";
 
- // Check this event for 2-touch Move/Pinch/Zoom gesture
- handle_pinch_zoom(ev);
-}
+        // Check this event for 2-touch Move/Pinch/Zoom gesture
+        handle_pinch_zoom(ev);
+      }
 
-function end_handler(ev) {
-  ev.preventDefault();
-  if (logEvents) log(ev.type, ev, false);
-  if (ev.targetTouches.length == 0) {
-    // Restore background and outline to original values
-    ev.target.style.background = "white";
-    ev.target.style.outline = "1px solid black";
-  }
-}
+      function end_handler(ev) {
+        ev.preventDefault();
+        if (logEvents) log(ev.type, ev, false);
+        if (ev.targetTouches.length == 0) {
+          // Restore background and outline to original values
+          ev.target.style.background = "white";
+          ev.target.style.outline = "1px solid black";
+        }
+      }
 
-function set_handlers(name) {
- // Install event handlers for the given element
- var el=document.getElementById(name);
- el.ontouchstart = start_handler;
- el.ontouchmove = move_handler;
- // Use same handler for touchcancel and touchend
- el.ontouchcancel = end_handler;
- el.ontouchend = end_handler;
-}
+      function set_handlers(name) {
+        // Install event handlers for the given element
+        var el = document.getElementById(name);
+        el.ontouchstart = start_handler;
+        el.ontouchmove = move_handler;
+        // Use same handler for touchcancel and touchend
+        el.ontouchcancel = end_handler;
+        el.ontouchend = end_handler;
+      }
 
-function init() {
- set_handlers("target1");
- set_handlers("target2");
- set_handlers("target3");
- set_handlers("target4");
-}
+      function init() {
+        set_handlers("target1");
+        set_handlers("target2");
+        set_handlers("target3");
+        set_handlers("target4");
+      }
+    </script>
+  </head>
+  <body onload="init();">
+    <h1>Multi-touch interaction</h1>
+    <!-- Create some boxes to test various gestures. -->
+    <div id="target1">Tap, Hold or Swipe me 1</div>
+    <div id="target2">Tap, Hold or Swipe me 2</div>
+    <div id="target3">Tap, Hold or Swipe me 3</div>
+    <div id="target4">Tap, Hold or Swipe me 4</div>
 
-</script>
-<body onload="init();">
-<h1>Multi-touch interaction</h1>
- <!-- Create some boxes to test various gestures. -->
- <div id="target1"> Tap, Hold or Swipe me 1</div>
- <div id="target2"> Tap, Hold or Swipe me 2</div>
- <div id="target3"> Tap, Hold or Swipe me 3</div>
- <div id="target4"> Tap, Hold or Swipe me 4</div>
-
- <!-- UI for logging/debugging -->
- <button id="log" onclick="enableLog(event);">Start/Stop event logging</button>
- <button id="clearlog" onclick="clearLog(event);">Clear the log</button>
- <p></p>
- <output></output>
-</body>
+    <!-- UI for logging/debugging -->
+    <button id="log" onclick="enableLog(event);">
+      Start/Stop event logging
+    </button>
+    <button id="clearlog" onclick="clearLog(event);">Clear the log</button>
+    <p></p>
+    <output></output>
+  </body>
 </html>

--- a/web-crypto/derive-bits/index.html
+++ b/web-crypto/derive-bits/index.html
@@ -49,7 +49,8 @@
       </section>
     </main>
 
-  </body>
+
   <script src="pbkdf2.js"></script>
   <script src="ecdh.js"></script>
+</body>
 </html>

--- a/web-crypto/derive-key/index.html
+++ b/web-crypto/derive-key/index.html
@@ -179,8 +179,9 @@
         </section>
       </section>
     </main>
-  </body>
+
   <script src="ecdh.js"></script>
   <script src="pbkdf2.js"></script>
   <script src="hkdf.js"></script>
+</body>
 </html>

--- a/web-crypto/encrypt-decrypt/index.html
+++ b/web-crypto/encrypt-decrypt/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Web Crypto API example</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
   </head>
 
   <body>
@@ -11,29 +11,49 @@
       <h1>Web Crypto: encrypt/decrypt</h1>
 
       <section class="description">
-        <p>This page shows the use of the <code>encrypt()</code> and <code>decrypt()</code> functions of the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API">Web Crypto API</a>. It contains four separate examples, one for each encryption algorithm supported:</p>
+        <p>
+          This page shows the use of the <code>encrypt()</code> and
+          <code>decrypt()</code> functions of the
+          <a
+            href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API"
+            >Web Crypto API</a
+          >. It contains four separate examples, one for each encryption
+          algorithm supported:
+        </p>
         <ul>
           <li>"RSA-OAEP"</li>
           <li>"AES-CTR"</li>
           <li>"AES-CBC"</li>
           <li>"AES-GCM"</li>
         </ul>
-        <hr/>
+        <hr />
         <p>Each example has five components:</p>
         <ul>
           <li>A text box containing a message to encrypt.</li>
           <li>A representation of the ciphertext.</li>
           <li>A box that will contain the decrypted ciphertext.</li>
-          <li>An "Encrypt" button: this encrypts the text box contents, displays part of the ciphertext, and stores the complete ciphertext.</li>
-          <li>A "Decrypt" button: this decrypts the ciphertext and writes the result into the "Decrypted" box.</li>
+          <li>
+            An "Encrypt" button: this encrypts the text box contents, displays
+            part of the ciphertext, and stores the complete ciphertext.
+          </li>
+          <li>
+            A "Decrypt" button: this decrypts the ciphertext and writes the
+            result into the "Decrypted" box.
+          </li>
         </ul>
         <p>Try it:</p>
         <ul>
           <li>Press "Encrypt". The ciphertext should appear.</li>
-          <li>Press "Decrypt". The decrypted text should appear, and match the original message.</li>
+          <li>
+            Press "Decrypt". The decrypted text should appear, and match the
+            original message.
+          </li>
           <li>Edit the text box contents.</li>
           <li>Press "Encrypt" again. A different ciphertext should appear.</li>
-          <li>Press "Decrypt" again. The new text box contents should appear next to "Decrypted:".</li>
+          <li>
+            Press "Decrypt" again. The new text box contents should appear next
+            to "Decrypted:".
+          </li>
         </ul>
       </section>
 
@@ -43,13 +63,21 @@
           <section class="encrypt-decrypt-controls">
             <div class="message-control">
               <label for="rsa-oaep-message">Enter a message to encrypt:</label>
-              <input type="text" id="rsa-oaep-message" name="message" size="25"
-                     value="The owl hoots at midnight">
+              <input
+                type="text"
+                id="rsa-oaep-message"
+                name="message"
+                size="25"
+                value="The owl hoots at midnight" />
             </div>
-            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
-            <div class="decrypted">Decrypted:<span class="decrypted-value"></span></div>
-            <input class="encrypt-button" type="button" value="Encrypt">
-            <input class="decrypt-button" type="button" value="Decrypt">
+            <div class="ciphertext">
+              Ciphertext:<span class="ciphertext-value"></span>
+            </div>
+            <div class="decrypted">
+              Decrypted:<span class="decrypted-value"></span>
+            </div>
+            <input class="encrypt-button" type="button" value="Encrypt" />
+            <input class="decrypt-button" type="button" value="Decrypt" />
           </section>
         </section>
 
@@ -58,13 +86,21 @@
           <section class="encrypt-decrypt-controls">
             <div class="message-control">
               <label for="aes-ctr-message">Enter a message to encrypt:</label>
-              <input type="text" id="aes-ctr-message" name="message" size="25"
-                     value="The tiger prowls at dawn">
+              <input
+                type="text"
+                id="aes-ctr-message"
+                name="message"
+                size="25"
+                value="The tiger prowls at dawn" />
             </div>
-            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
-            <div class="decrypted">Decrypted:<span class="decrypted-value"></span></div>
-            <input class="encrypt-button" type="button" value="Encrypt">
-            <input class="decrypt-button" type="button" value="Decrypt">
+            <div class="ciphertext">
+              Ciphertext:<span class="ciphertext-value"></span>
+            </div>
+            <div class="decrypted">
+              Decrypted:<span class="decrypted-value"></span>
+            </div>
+            <input class="encrypt-button" type="button" value="Encrypt" />
+            <input class="decrypt-button" type="button" value="Decrypt" />
           </section>
         </section>
 
@@ -73,13 +109,21 @@
           <section class="encrypt-decrypt-controls">
             <div class="message-control">
               <label for="aes-cbc-message">Enter a message to encrypt:</label>
-              <input type="text" id="aes-cbc-message" name="message" size="25"
-                     value="The eagle flies at twilight">
+              <input
+                type="text"
+                id="aes-cbc-message"
+                name="message"
+                size="25"
+                value="The eagle flies at twilight" />
             </div>
-            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
-            <div class="decrypted">Decrypted:<span class="decrypted-value"></span></div>
-            <input class="encrypt-button" type="button" value="Encrypt">
-            <input class="decrypt-button" type="button" value="Decrypt">
+            <div class="ciphertext">
+              Ciphertext:<span class="ciphertext-value"></span>
+            </div>
+            <div class="decrypted">
+              Decrypted:<span class="decrypted-value"></span>
+            </div>
+            <input class="encrypt-button" type="button" value="Encrypt" />
+            <input class="decrypt-button" type="button" value="Decrypt" />
           </section>
         </section>
 
@@ -88,22 +132,29 @@
           <section class="encrypt-decrypt-controls">
             <div class="message-control">
               <label for="aes-gcm-message">Enter a message to encrypt:</label>
-              <input type="text" id="aes-gcm-message" name="message" size="25"
-                     value="The bunny hops at teatime">
+              <input
+                type="text"
+                id="aes-gcm-message"
+                name="message"
+                size="25"
+                value="The bunny hops at teatime" />
             </div>
-            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
-            <div class="decrypted">Decrypted:<span class="decrypted-value"></span></div>
-            <input class="encrypt-button" type="button" value="Encrypt">
-            <input class="decrypt-button" type="button" value="Decrypt">
+            <div class="ciphertext">
+              Ciphertext:<span class="ciphertext-value"></span>
+            </div>
+            <div class="decrypted">
+              Decrypted:<span class="decrypted-value"></span>
+            </div>
+            <input class="encrypt-button" type="button" value="Encrypt" />
+            <input class="decrypt-button" type="button" value="Decrypt" />
           </section>
         </section>
-
       </section>
     </main>
 
+    <script src="rsa-oaep.js"></script>
+    <script src="aes-cbc.js"></script>
+    <script src="aes-ctr.js"></script>
+    <script src="aes-gcm.js"></script>
   </body>
-  <script src="rsa-oaep.js"></script>
-  <script src="aes-cbc.js"></script>
-  <script src="aes-ctr.js"></script>
-  <script src="aes-gcm.js"></script>
 </html>

--- a/web-crypto/export-key/index.html
+++ b/web-crypto/export-key/index.html
@@ -43,9 +43,10 @@
 
     </main>
 
-  </body>
+
   <script src="raw.js"></script>
   <script src="pkcs8.js"></script>
   <script src="spki.js"></script>
   <script src="jwk.js"></script>
+</body>
 </html>

--- a/web-crypto/import-key/index.html
+++ b/web-crypto/import-key/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Web Crypto API example</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
   </head>
 
   <body>
@@ -11,37 +11,63 @@
       <h1>Web Crypto: importKey</h1>
 
       <section class="description">
-        <p>This page shows the use of the <code>importKey()</code> function of the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API">Web Crypto API</a>. It contains four separate examples, one for each import format supported:</p>
+        <p>
+          This page shows the use of the <code>importKey()</code> function of
+          the
+          <a
+            href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API"
+            >Web Crypto API</a
+          >. It contains four separate examples, one for each import format
+          supported:
+        </p>
         <ul>
           <li>Raw</li>
           <li>PKCS #8</li>
           <li>SubjectPublicKeyInfo</li>
           <li>JSON Web Key</li>
         </ul>
-        <p>Each example has the same structure: you get a message a button labeled "Import Key".</p>
-        <p>If you click "Import Key" then the example imports a particular key:</p>
+        <p>
+          Each example has the same structure: you get a message a button
+          labeled "Import Key".
+        </p>
+        <p>
+          If you click "Import Key" then the example imports a particular key:
+        </p>
         <ul>
           <li>For "Raw", an AES encryption key.</li>
           <li>For "PKCS #8", an RSA private signing key.</li>
           <li>For "SubjectPublicKeyInfo", an RSA public encryption key.</li>
           <li>For "JSON Web Key", an EC private signing key.</li>
         </ul>
-        <p>A new button is then displayed, labeled "Sign" or "Encrypt", depending on the key that was imported. You can click it to use the imported key to perform the appropriate operation and display the result.</p>
+        <p>
+          A new button is then displayed, labeled "Sign" or "Encrypt", depending
+          on the key that was imported. You can click it to use the imported key
+          to perform the appropriate operation and display the result.
+        </p>
       </section>
 
       <section class="examples">
-
         <section class="import-key raw">
           <h2 class="import-key-heading">Raw</h2>
           <section class="import-key-controls">
             <div class="message-control">
               <label for="raw-message">Enter a message to encrypt:</label>
-              <input type="text" id="raw-message" name="message" size="25"
-                     value="The owl hoots at midnight">
+              <input
+                type="text"
+                id="raw-message"
+                name="message"
+                size="25"
+                value="The owl hoots at midnight" />
             </div>
-            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
-            <input class="import-key-button" type="button" value="Import Key">
-            <input class="encrypt-button hidden" type="button" value="Encrypt" disabled>
+            <div class="ciphertext">
+              Ciphertext:<span class="ciphertext-value"></span>
+            </div>
+            <input class="import-key-button" type="button" value="Import Key" />
+            <input
+              class="encrypt-button hidden"
+              type="button"
+              value="Encrypt"
+              disabled />
           </section>
         </section>
 
@@ -50,12 +76,22 @@
           <section class="import-key-controls">
             <div class="message-control">
               <label for="pkcs8-message">Enter a message to sign:</label>
-              <input type="text" id="pkcs8-message" name="message" size="25"
-                     value="The tiger prowls at dawn">
+              <input
+                type="text"
+                id="pkcs8-message"
+                name="message"
+                size="25"
+                value="The tiger prowls at dawn" />
             </div>
-            <div class="signature">Signature:<span class="signature-value"></span></div>
-            <input class="import-key-button" type="button" value="Import Key">
-            <input class="sign-button hidden" type="button" value="Sign" disabled>
+            <div class="signature">
+              Signature:<span class="signature-value"></span>
+            </div>
+            <input class="import-key-button" type="button" value="Import Key" />
+            <input
+              class="sign-button hidden"
+              type="button"
+              value="Sign"
+              disabled />
           </section>
         </section>
 
@@ -64,12 +100,22 @@
           <section class="import-key-controls">
             <div class="message-control">
               <label for="spki-message">Enter a message to encrypt:</label>
-              <input type="text" id="spki-message" name="message" size="25"
-                     value="The eagle flies at twilight">
+              <input
+                type="text"
+                id="spki-message"
+                name="message"
+                size="25"
+                value="The eagle flies at twilight" />
             </div>
-            <div class="ciphertext">Ciphertext:<span class="ciphertext-value"></span></div>
-            <input class="import-key-button" type="button" value="Import Key">
-            <input class="encrypt-button hidden" type="button" value="Encrypt" disabled>
+            <div class="ciphertext">
+              Ciphertext:<span class="ciphertext-value"></span>
+            </div>
+            <input class="import-key-button" type="button" value="Import Key" />
+            <input
+              class="encrypt-button hidden"
+              type="button"
+              value="Encrypt"
+              disabled />
           </section>
         </section>
 
@@ -78,21 +124,30 @@
           <section class="import-key-controls">
             <div class="message-control">
               <label for="jwk-message">Enter a message to sign:</label>
-              <input type="text" id="jwk-message" name="message" size="25"
-                     value="The bunny hops at teatime">
+              <input
+                type="text"
+                id="jwk-message"
+                name="message"
+                size="25"
+                value="The bunny hops at teatime" />
             </div>
-            <div class="signature">Signature:<span class="signature-value"></span></div>
-            <input class="import-key-button" type="button" value="Import Key">
-            <input class="sign-button hidden" type="button" value="Sign" disabled>
+            <div class="signature">
+              Signature:<span class="signature-value"></span>
+            </div>
+            <input class="import-key-button" type="button" value="Import Key" />
+            <input
+              class="sign-button hidden"
+              type="button"
+              value="Sign"
+              disabled />
           </section>
         </section>
-
       </section>
     </main>
 
+    <script src="raw.js"></script>
+    <script src="pkcs8.js"></script>
+    <script src="spki.js"></script>
+    <script src="jwk.js"></script>
   </body>
-  <script src="raw.js"></script>
-  <script src="pkcs8.js"></script>
-  <script src="spki.js"></script>
-  <script src="jwk.js"></script>
 </html>

--- a/web-crypto/sign-verify/index.html
+++ b/web-crypto/sign-verify/index.html
@@ -88,8 +88,7 @@
                 id="rsassa-pkcs1-message"
                 name="message"
                 size="25"
-                value="The owl hoots at midnight"
-              />
+                value="The owl hoots at midnight" />
             </div>
             <div class="signature">
               Signature:<span class="signature-value"></span>
@@ -109,8 +108,7 @@
                 id="rsa-pss-message"
                 name="message"
                 size="25"
-                value="The tiger prowls at dawn"
-              />
+                value="The tiger prowls at dawn" />
             </div>
             <div class="signature">
               Signature:<span class="signature-value"></span>
@@ -130,8 +128,7 @@
                 id="ecdsa-message"
                 name="message"
                 size="25"
-                value="The eagle flies at twilight"
-              />
+                value="The eagle flies at twilight" />
             </div>
             <div class="signature">
               Signature:<span class="signature-value"></span>
@@ -151,8 +148,7 @@
                 id="hmac-message"
                 name="message"
                 size="25"
-                value="The bunny hops at teatime"
-              />
+                value="The bunny hops at teatime" />
             </div>
             <div class="signature">
               Signature:<span class="signature-value"></span>
@@ -172,8 +168,7 @@
                 id="ed25519-message"
                 name="message"
                 size="25"
-                value="The lion roars near dawn"
-              />
+                value="The lion roars near dawn" />
             </div>
             <div class="signature">
               Signature:<span class="signature-value"></span>
@@ -184,10 +179,11 @@
         </section>
       </section>
     </main>
+
+    <script src="rsassa-pkcs1.js"></script>
+    <script src="rsa-pss.js"></script>
+    <script src="ecdsa.js"></script>
+    <script src="hmac.js"></script>
+    <script src="ed25519.js"></script>
   </body>
-  <script src="rsassa-pkcs1.js"></script>
-  <script src="rsa-pss.js"></script>
-  <script src="ecdsa.js"></script>
-  <script src="hmac.js"></script>
-  <script src="ed25519.js"></script>
 </html>

--- a/web-crypto/unwrap-key/index.html
+++ b/web-crypto/unwrap-key/index.html
@@ -54,7 +54,8 @@
       </section>
     </main>
 
-  </body>
+
   <script src="raw.js"></script>
   <script src="pkcs8.js"></script>
+</body>
 </html>

--- a/web-crypto/wrap-key/index.html
+++ b/web-crypto/wrap-key/index.html
@@ -44,9 +44,10 @@
 
     </main>
 
-  </body>
+
   <script src="raw.js"></script>
   <script src="pkcs8.js"></script>
   <script src="spki.js"></script>
   <script src="jwk.js"></script>
+</body>
 </html>

--- a/web-storage/event.html
+++ b/web-storage/event.html
@@ -1,31 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width" />
 
     <title>Web Storage API storage event output</title>
 
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
   </head>
 
   <body>
-  <div class="wrapper">
-    <h1>Event output</h1>
+    <div class="wrapper">
+      <h1>Event output</h1>
 
-    <ul>
-      <li>Key: <span class="my-key"></span></li>
-      <li>Old value: <span class="my-old"></span></li>
-      <li>New value: <span class="my-new"></span></li>
-      <li>URL: <span class="my-url"></span></li>
-      <li>Storage area: <span class="my-storage"></span></li>
-    </ul>
+      <ul>
+        <li>Key: <span class="my-key"></span></li>
+        <li>Old value: <span class="my-old"></span></li>
+        <li>New value: <span class="my-new"></span></li>
+        <li>URL: <span class="my-url"></span></li>
+        <li>Storage area: <span class="my-storage"></span></li>
+      </ul>
 
-    <p>Go back to the <a href="index.html">main example page</a>.</p>
-
-
-  </div>
+      <p>Go back to the <a href="index.html">main example page</a>.</p>
+    </div>
+    <script src="event.js"></script>
   </body>
-  <script src="event.js"></script>
 </html>

--- a/web-storage/index.html
+++ b/web-storage/index.html
@@ -1,48 +1,61 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width" />
 
     <title>Web Storage API example</title>
 
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
   </head>
 
   <body>
-  <div class="wrapper">
-    <h1>Web storage</h1>
+    <div class="wrapper">
+      <h1>Web storage</h1>
 
-    <p>This example is designed to demonstrate usage of the <a href="https://html.spec.whatwg.org/multipage/webstorage.html#webstorage">W3C Web Storage API</a>. It should work as far back as IE8. Choose custom background colours, logos and fonts from the below drop down menus, then try closing and reopening the page — you will find that your choices are remembered, as they are stored using Web Storage. You can also visit the <a href="event.html" target="_blank">storage event output</a> (opens in new tab). Open this, change some values in the index page, then look at the events page — you'll see the storage changes reported.</p>
+      <p>
+        This example is designed to demonstrate usage of the
+        <a
+          href="https://html.spec.whatwg.org/multipage/webstorage.html#webstorage"
+          >W3C Web Storage API</a
+        >. It should work as far back as IE8. Choose custom background colours,
+        logos and fonts from the below drop down menus, then try closing and
+        reopening the page — you will find that your choices are remembered, as
+        they are stored using Web Storage. You can also visit the
+        <a href="event.html" target="_blank">storage event output</a> (opens in
+        new tab). Open this, change some values in the index page, then look at
+        the events page — you'll see the storage changes reported.
+      </p>
 
-    <form>
-      <div>
-        <label for="bgcolor">Choose background color:</label>
-	    <input class="color" id="bgcolor" value="FF0000">
-      </div>
-      <div>
-        <label for="font">Choose font style:</label>
-        <select id="font">
-        	<option value="sans-serif" selected>Sans-serif</option>
-        	<option value="serif">Serif</option>
-        	<option value="monospace">Monospace</option>
-        </select>
-      </div>
-      <div>
-        <label for="image">Choose image:</label>
-        <select id="image">
-        	<option value="images/firefoxos.png" selected>Firefox</option>
-        	<option value="images/crocodile.png">Crocodile</option>
-        	<option value="images/tortoise.png">Tortoise</option>
-        </select>
-      </div>
-    </form>
+      <form>
+        <div>
+          <label for="bgcolor">Choose background color:</label>
+          <input class="color" id="bgcolor" value="FF0000" />
+        </div>
+        <div>
+          <label for="font">Choose font style:</label>
+          <select id="font">
+            <option value="sans-serif" selected>Sans-serif</option>
+            <option value="serif">Serif</option>
+            <option value="monospace">Monospace</option>
+          </select>
+        </div>
+        <div>
+          <label for="image">Choose image:</label>
+          <select id="image">
+            <option value="images/firefoxos.png" selected>Firefox</option>
+            <option value="images/crocodile.png">Crocodile</option>
+            <option value="images/tortoise.png">Tortoise</option>
+          </select>
+        </div>
+      </form>
 
-    <footer></footer>
-    <img src="images/firefoxos.png">
-  </div>
+      <footer></footer>
+      <img src="images/firefoxos.png" />
+    </div>
+
+    <script src="jscolor/jscolor.js"></script>
+    <script src="main.js"></script>
   </body>
-  <script src="jscolor/jscolor.js"></script>
-  <script src="main.js"></script>
 </html>


### PR DESCRIPTION
This PR fixes HTML validation errors relating to where the script element is permitted.

__Changes:__
* Prettier formatting in parallel in changed files
* `<script>` elements moved inside `<head>` or `<body>`

__Additions:__
* `html-validate` config - see https://html-validate.org/usage/index.html


There are two html-validate violations for the `element-permitted-content` rule left over after this PR:

```bash
html-validate ./**/*.html | grep -B 2 element-permitted-content
# dom-examples/popover-api/toggle-help-ui/index.html
#  24:6   error  <button> is missing recommended "type" attribute     no-implicit-button-type
#  37:10  error  <hr> element is not permitted as content under <ul>  element-permitted-content
#
# dom-examples/shadow-dom/shadowrootmode/scoping.html
#  16:8  error  <style> element is not permitted as content under <article>  element-permitted-content
```

## How to review this PR

To ignore whitespace-only changes, view files using the following view:

https://github.com/mdn/dom-examples/pull/268/files?diff=split&w=1

Fixes #267 