### PR TITLE
MessageChannel-postMessage-error-handle

### DIFF
--- a/channel-messaging-multimessage/page2.html
+++ b/channel-messaging-multimessage/page2.html
@@ -24,8 +24,10 @@
 
       // Setup the transfered port
       function initPort(e) {
-        port2 = e.ports[0];
-        port2.onmessage = onMessage;
+        if (e.ports[0]) {
+          port2 = e.ports[0];
+          port2.onmessage = onMessage;
+        }
       }
 
       // Handle messages received on port2


### PR DESCRIPTION
If there is a special plugin in chrome that listens for postMessage, it will throw an error
![image](https://github.com/mdn/dom-examples/assets/29154358/cf77f797-045e-40e4-901f-ce9fb092895a)
![image](https://github.com/mdn/dom-examples/assets/29154358/001642de-b6eb-466e-a2f2-f3004ecc352b)
