### PR TITLE
fix: tidy up fetch init with request example

### DIFF
--- a/fetch/fetch-request-with-init/index.html
+++ b/fetch/fetch-request-with-init/index.html
@@ -17,18 +17,19 @@
     <script>
       const myImage = document.querySelector("img");
 
-      const myHeaders = new Headers();
+      const reqHeaders = new Headers();
 
-      const myOptions = {
-        method: "GET",
-        headers: myHeaders,
-        mode: "cors",
-        cache: "default",
+      // a cached response is okay unless it's more than a week old
+      reqHeaders.set("Cache-Control", "max-age=604800");
+
+      const options = {
+        headers: reqHeaders,
       };
 
-      const myRequest = new Request("flowers.jpg", myOptions);
+      // pass init as an "options" object with our headers
+      const req = new Request("flowers.jpg", options);
 
-      fetch(myRequest)
+      fetch(req)
         .then((response) => {
           if (!response.ok) {
             throw new Error(`HTTP error, status = ${response.status}`);


### PR DESCRIPTION
__Description:__

There's a couple of improvements here to get rid of redundant code for the GET request. I believe the `method`, `mode` and `cache` properties are all defaults, so I'm leaving the headers as something a reader is likely to customize with auth, or caching, or something custom.

No real preference on the following:

```js
const req = new Request("flowers.jpg", options);
fetch(req)
```

vs

```js
const req = new Request("flowers.jpg");
fetch(req, options)
```

Fixes #151 


__Related issues and pull requests:__

- [ ] TODO content PR