### PR TITLE
fix: remove extra semicolons in web-share example

### DIFF
--- a/web-share/index.html
+++ b/web-share/index.html
@@ -38,10 +38,10 @@
         }
         navigator.share(shareData)
           .then(() =>
-            resultPara.textContent = 'MDN shared successfully';
+            resultPara.textContent = 'MDN shared successfully'
           )
           .catch((e) =>
-            resultPara.textContent = 'Error: ' + e;
+            resultPara.textContent = 'Error: ' + e
           )
       });
     </script>


### PR DESCRIPTION
@pepelsbey @mrienstra I noticed a small bug that was introduced in #227. There are a couple of places where a semicolon comes after a function argument, which makes the code invalid. Easiest to show from linting:

<img width="500" alt="Screenshot 2024-07-23 at 3 05 56 PM" src="https://github.com/user-attachments/assets/6ee0fe88-0b57-4cdc-8877-e78b81cde006">
