### PR TITLE
Small tweak to visual viewport example wording

### DIFF
--- a/visual-viewport-api/index.html
+++ b/visual-viewport-api/index.html
@@ -9,8 +9,9 @@
 </head>
 
 <body>
-  <p id="instructions">Try scrolling around on a desktop and a mobile browser to see how the reported values change.
-    Also try pinch/zooming on a mobile browser to see the effect.</p>
+  <p id="instructions">
+    Try scrolling around and pinch-zooming to see how the reported values change.
+  </p>
   <div id="output">
     <p id="visual-info"></p>
     <hr>


### PR DESCRIPTION
This PR updates the text in the HTML of the visual viewport example to match the same text change made in the example explanation in the docs (see https://github.com/mdn/content/pull/34427).