### PR TITLE
Fix dictaphone buffer length

### DIFF
--- a/media/web-dictaphone/scripts/app.js
+++ b/media/web-dictaphone/scripts/app.js
@@ -117,9 +117,9 @@ function visualize(stream) {
 
   const source = audioCtx.createMediaStreamSource(stream);
 
+  const bufferLength = 2048;
   const analyser = audioCtx.createAnalyser();
-  analyser.fftSize = 2048;
-  const bufferLength = analyser.fftSize;
+  analyser.fftSize = bufferLength;
   const dataArray = new Uint8Array(bufferLength);
 
   source.connect(analyser);

--- a/media/web-dictaphone/scripts/app.js
+++ b/media/web-dictaphone/scripts/app.js
@@ -119,7 +119,7 @@ function visualize(stream) {
 
   const analyser = audioCtx.createAnalyser();
   analyser.fftSize = 2048;
-  const bufferLength = analyser.frequencyBinCount;
+  const bufferLength = analyser.fftSize;
   const dataArray = new Uint8Array(bufferLength);
 
   source.connect(analyser);


### PR DESCRIPTION
After coming across [this StackOverflow answer](https://stackoverflow.com/a/60953587/2180570), I believe since the dictaphone is showing `getByteTimeDomainData`, the buffer length should be the `fftSize`, not the `frequencyBinCount` (`fftSize`/2). I'm not an expert in audio processing, but the comments on that post seem to confirm this, and it is also backed up by it working this way in [this other MDN example on `getFloatTimeDomainData`](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getFloatTimeDomainData#examples).

I guess it's not really a big deal, practically speaking in the case of this example. It's just throwing out half of its wave data every frame, but you can still get a good idea of your mic signal. But a lot of people follow this example for education purposes, and I think it should be fully correct.