### PR TITLE
fix audio source scope to enable stopping playback

### DIFF
--- a/fetch/fetch-array-buffer/index.html
+++ b/fetch/fetch-array-buffer/index.html
@@ -25,6 +25,7 @@
       const play = document.querySelector(".play");
       const stop = document.querySelector(".stop");
       const errorDisplay = document.querySelector(".error");
+      let currentSource = null; 
 
       // use fetch to load an audio track, and
       // decodeAudioData to decode it and stick it in a buffer.
@@ -53,7 +54,8 @@
         getData()
           .then((source) => {
             errorDisplay.innerHTML = "";
-            source.start(0);
+            currentSource = source;
+            currentSource.start(0);
             play.disabled = true;
           })
           .catch((error) => {
@@ -64,8 +66,10 @@
       };
 
       stop.onclick = () => {
-        source.stop(0);
-        play.disabled = false;
+        if(currentSource){
+          currentSource.stop(0);
+          play.disabled = false;
+        }
       };
 
       // dump script to pre element

--- a/fetch/fetch-array-buffer/index.html
+++ b/fetch/fetch-array-buffer/index.html
@@ -66,7 +66,7 @@
       };
 
       stop.onclick = () => {
-        if(currentSource){
+        if (currentSource){
           currentSource.stop(0);
           play.disabled = false;
         }


### PR DESCRIPTION
- **Issue:** The audio source [created here](https://github.com/mdn/dom-examples/blob/085b5952ccc3171b1075c4027868b191a745d3cf/fetch/fetch-array-buffer/index.html#L44) is accessible to the `play()` function, but **inaccessible** to the `stop()` function. As a result, the `stop` button **fails to stop** the audio playback.
- **Fix:** Moved audio source to a globally accessible variable (`currentSource`), allowing the `stop()` function to access it and stop the playback. Added a check to ensure `stop()` is only called when a valid source exists.






