### PR TITLE
Add popover=hint example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "pointer-lock" directory contains a basic demo to show usage of the Pointer Lock API. You can find more explanation of how the demo works at the main MDN [Pointer Lock API](https://developer.mozilla.org/docs/Web/API/Pointer_Lock_API) page. [Run the demo live](https://mdn.github.io/dom-examples/pointer-lock/).
 
-- The "popover-api" directory is for examples and demos of the [Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API) standard. Go to the [Popover API demo index](https://mdn.github.io/dom-examples/popoover-api/) to see what's available.
+- The "popover-api" directory is for examples and demos of the [Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API) standard. Go to the [Popover API demo index](https://mdn.github.io/dom-examples/popover-api/) to see what's available.
 
 - The "reporting-api" directory contains a couple of basic demos to show usage of the Reporting API. You can find more explanation of how the API works in the main MDN [Reporting API](https://developer.mozilla.org/docs/Web/API/Reporting_API) docs. [Run the deprecation report demo live](https://mdn.github.io/dom-examples/reporting-api/deprecation_report.html).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "pointer-lock" directory contains a basic demo to show usage of the Pointer Lock API. You can find more explanation of how the demo works at the main MDN [Pointer Lock API](https://developer.mozilla.org/docs/Web/API/Pointer_Lock_API) page. [Run the demo live](https://mdn.github.io/dom-examples/pointer-lock/).
 
-- The "popover-api" directory is for examples and demos of the [Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API) standard. Go to the [Popover API demo index](popover-api/) to see what's available.
+- The "popover-api" directory is for examples and demos of the [Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API) standard. Go to the [Popover API demo index](https://mdn.github.io/dom-examples/popoover-api/) to see what's available.
 
 - The "reporting-api" directory contains a couple of basic demos to show usage of the Reporting API. You can find more explanation of how the API works in the main MDN [Reporting API](https://developer.mozilla.org/docs/Web/API/Reporting_API) docs. [Run the deprecation report demo live](https://mdn.github.io/dom-examples/reporting-api/deprecation_report.html).
 

--- a/popover-api/index.html
+++ b/popover-api/index.html
@@ -24,13 +24,14 @@
         Demonstrates a basic auto state popover.
       </li>
       <li>
-        <a href="blur-background/">Blur background popover example</a>: Shows how
-        you can add styling to the content behind the popover using the
+        <a href="blur-background/">Blur background popover example</a>: Shows
+        how you can add styling to the content behind the popover using the
         <code>::backdrop</code> pseudo-element.
       </li>
       <li>
-        <a href="multiple-auto/">Multiple auto popovers example</a>: Demonstrates
-        that, generally, only one auto popover can be displayed at once.
+        <a href="multiple-auto/">Multiple auto popovers example</a>:
+        Demonstrates that, generally, only one auto popover can be displayed at
+        once.
       </li>
       <li>
         <a href="multiple-manual/">Multiple manual popovers example</a>:
@@ -42,13 +43,20 @@
         the behavior of nested auto state popovers.
       </li>
       <li>
-        <a href="popover-positioning/">Popover positioning example</a>: An
-        isolated example showing CSS overriding of the default popover positioning
-        specified by the UA sylesheet.
+        <a href="popover-hint/">popover="hint" example</a>: This example shows
+        how to use the <code>popover="hint"</code> value to create tooltip
+        popovers that show on button mouseover and focus, without dismissing the
+        <code>auto</code> popovers shown when the buttons are clicked on. The
+        <code>hint</code> popovers are controlled via JavaScript.
       </li>
       <li>
-        <a href="toggle-help-ui/">Toggle help UI example</a>: Shows the basics of
-        using JavaScript to control popover showing and hiding.
+        <a href="popover-positioning/">Popover positioning example</a>: An
+        isolated example showing CSS overriding of the default popover
+        positioning specified by the UA sylesheet.
+      </li>
+      <li>
+        <a href="toggle-help-ui/">Toggle help UI example</a>: Shows the basics
+        of using JavaScript to control popover showing and hiding.
       </li>
       <li>
         <a href="toast-popovers/">Toast popovers example</a>: Illustrates how to

--- a/popover-api/popover-hint/index.css
+++ b/popover-api/popover-hint/index.css
@@ -7,6 +7,7 @@
 html {
   font-family: sans-serif;
   height: 100%;
+  overflow: hidden;
 }
 
 body {
@@ -109,4 +110,17 @@ body {
   color: whitesmoke;
   box-shadow: 1px 1px 3px #999;
   border: none;
+}
+
+/* Styling help para */
+
+.help-para {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  background: #eee;
+  width: 300px;
+  margin: 0;
+  padding: 16px;
+  box-shadow: 1px 1px 3px #999;
 }

--- a/popover-api/popover-hint/index.css
+++ b/popover-api/popover-hint/index.css
@@ -1,0 +1,148 @@
+/* General styling */
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: sans-serif;
+  height: 100%;
+}
+
+body {
+  height: inherit;
+  background: #ccc;
+  margin: 0;
+}
+
+#wrapper {
+  height: inherit;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Button bar styling */
+
+#button-bar {
+  height: 48px;
+  width: 30%;
+  min-width: 300px;
+  padding: 8px;
+  border-radius: 6px;
+  background: #eee;
+  box-shadow: 1px 1px 3px #999;
+  display: flex;
+  justify-content: space-around;
+  gap: 10px;
+}
+
+/* Button styling */
+
+#button-bar button {
+  border: 1px solid #999;
+  border-radius: 4px;
+  background: #eee;
+  flex: 1;
+}
+
+#button-bar button:hover,
+#button-bar button:focus {
+  background: #ccc;
+}
+
+#button-bar button:active {
+  box-shadow: inset 1px 1px 2px #333, inset -1px -1px 2px #eee;
+}
+
+/* Anchoring and styling auto popovers */
+
+#menu-1 {
+  anchor-name: --menu-anchor-1, --tooltip-anchor-1;
+}
+
+#menu-2 {
+  anchor-name: --menu-anchor-2, --tooltip-anchor-2;
+}
+
+#menu-3 {
+  anchor-name: --menu-anchor-3, --tooltip-anchor-3;
+}
+
+[popover="auto"] {
+  inset: unset;
+  position: absolute;
+  bottom: calc(anchor(top) + 20px);
+  justify-self: anchor-center;
+  margin: 0;
+
+  width: 200px;
+  text-align: center;
+  padding: 8px;
+  border-radius: 6px;
+  background: #eee;
+  box-shadow: 1px 1px 3px #999;
+  border: none;
+}
+
+[popover="auto"] button {
+  border: 1px solid #999;
+  border-radius: 4px;
+  background: #eee;
+  width: 100%;
+  line-height: 1.5;
+}
+
+[popover="auto"] button:first-of-type {
+  margin-bottom: 8px;
+}
+
+[popover="auto"] button:hover,
+[popover="auto"] button:focus {
+  background: #ccc;
+}
+
+[popover="auto"] button:active {
+  box-shadow: inset 1px 1px 2px #333, inset -1px -1px 2px #eee;
+}
+
+#submenu-1 {
+  position-anchor: --menu-anchor-1;
+}
+
+#submenu-2 {
+  position-anchor: --menu-anchor-2;
+}
+
+#submenu-3 {
+  position-anchor: --menu-anchor-3;
+}
+
+/* Anchoring and styling hint popovers */
+
+#menu-1 {
+  position-anchor: --tooltip-anchor-1;
+}
+
+#tooltip-2 {
+  position-anchor: --tooltip-anchor-2;
+}
+
+#tooltip-3 {
+  position-anchor: --tooltip-anchor-3;
+}
+
+[popover="hint"] {
+  inset: unset;
+  position: absolute;
+  top: calc(anchor(bottom) + 5px);
+  justify-self: anchor-center;
+  margin: 0;
+
+  padding: 8px;
+  border-radius: 6px;
+  background: #271717;
+  color: whitesmoke;
+  box-shadow: 1px 1px 3px #999;
+  border: none;
+}

--- a/popover-api/popover-hint/index.css
+++ b/popover-api/popover-hint/index.css
@@ -55,19 +55,7 @@ body {
   box-shadow: inset 1px 1px 2px #333, inset -1px -1px 2px #eee;
 }
 
-/* Anchoring and styling auto popovers */
-
-#menu-1 {
-  anchor-name: --menu-anchor-1, --tooltip-anchor-1;
-}
-
-#menu-2 {
-  anchor-name: --menu-anchor-2, --tooltip-anchor-2;
-}
-
-#menu-3 {
-  anchor-name: --menu-anchor-3, --tooltip-anchor-3;
-}
+/* Styling auto popovers */
 
 [popover="auto"] {
   inset: unset;
@@ -106,31 +94,7 @@ body {
   box-shadow: inset 1px 1px 2px #333, inset -1px -1px 2px #eee;
 }
 
-#submenu-1 {
-  position-anchor: --menu-anchor-1;
-}
-
-#submenu-2 {
-  position-anchor: --menu-anchor-2;
-}
-
-#submenu-3 {
-  position-anchor: --menu-anchor-3;
-}
-
-/* Anchoring and styling hint popovers */
-
-#menu-1 {
-  position-anchor: --tooltip-anchor-1;
-}
-
-#tooltip-2 {
-  position-anchor: --tooltip-anchor-2;
-}
-
-#tooltip-3 {
-  position-anchor: --tooltip-anchor-3;
-}
+/* Styling hint popovers */
 
 [popover="hint"] {
   inset: unset;

--- a/popover-api/popover-hint/index.css
+++ b/popover-api/popover-hint/index.css
@@ -119,8 +119,18 @@ body {
   top: 16px;
   left: 16px;
   background: #eee;
-  width: 300px;
+  font-size: 0.8rem;
+  line-height: 1.3;
+  width: 50%;
+  max-width: 600px;
   margin: 0;
   padding: 16px;
   box-shadow: 1px 1px 3px #999;
+}
+
+@media (max-width: 640px) {
+  .help-para {
+    width: auto;
+    right: 16px;
+  }
 }

--- a/popover-api/popover-hint/index.html
+++ b/popover-api/popover-hint/index.html
@@ -13,24 +13,21 @@
         <button
           popovertarget="submenu-1"
           popovertargetaction="toggle"
-          id="menu-1"
-        >
+          id="menu-1">
           Menu A
         </button>
 
         <button
           popovertarget="submenu-2"
           popovertargetaction="toggle"
-          id="menu-2"
-        >
+          id="menu-2">
           Menu B
         </button>
 
         <button
           popovertarget="submenu-3"
           popovertargetaction="toggle"
-          id="menu-3"
-        >
+          id="menu-3">
           Menu C
         </button>
       </section>
@@ -46,8 +43,8 @@
       <button>Option A</button><br /><button>Option B</button>
     </div>
 
-    <div id="tooltip-1" class="tooltip" popover="hint">Hint A</div>
-    <div id="tooltip-2" class="tooltip" popover="hint">Hint B</div>
-    <div id="tooltip-3" class="tooltip" popover="hint">Hint C</div>
+    <div id="tooltip-1" class="tooltip" popover="hint">Tooltip A</div>
+    <div id="tooltip-2" class="tooltip" popover="hint">Tooltip B</div>
+    <div id="tooltip-3" class="tooltip" popover="hint">Tooltip C</div>
   </body>
 </html>

--- a/popover-api/popover-hint/index.html
+++ b/popover-api/popover-hint/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Popover hint example</title>
+    <link href="index.css" rel="stylesheet" />
+    <script src="index.js" defer></script>
+  </head>
+  <body>
+    <div id="wrapper">
+      <section id="button-bar">
+        <button
+          popovertarget="submenu-1"
+          popovertargetaction="toggle"
+          id="menu-1"
+        >
+          Menu A
+        </button>
+
+        <button
+          popovertarget="submenu-2"
+          popovertargetaction="toggle"
+          id="menu-2"
+        >
+          Menu B
+        </button>
+
+        <button
+          popovertarget="submenu-3"
+          popovertargetaction="toggle"
+          id="menu-3"
+        >
+          Menu C
+        </button>
+      </section>
+    </div>
+
+    <div id="submenu-1" popover="auto">
+      <button>Option A</button><br /><button>Option B</button>
+    </div>
+    <div id="submenu-2" popover="auto">
+      <button>Option A</button><br /><button>Option B</button>
+    </div>
+    <div id="submenu-3" popover="auto">
+      <button>Option A</button><br /><button>Option B</button>
+    </div>
+
+    <div id="tooltip-1" class="tooltip" popover="hint">Hint A</div>
+    <div id="tooltip-2" class="tooltip" popover="hint">Hint B</div>
+    <div id="tooltip-3" class="tooltip" popover="hint">Hint C</div>
+  </body>
+</html>

--- a/popover-api/popover-hint/index.html
+++ b/popover-api/popover-hint/index.html
@@ -35,13 +35,14 @@
 
     <p class="help-para">
       Press the buttons to show the auto popovers. Hover or focus the buttons to
-      show the hint popovers. Note how, when an auto popover is shown, you can
-      show the hint popovers without hiding it. See
+      show the hint popovers. When an auto popover is shown, you can show the
+      hint popovers without hiding it. See
       <a
         href="https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using#using_hint_popover_state"
         >Using "hint" popover state</a
       >
-      for more information.
+      for more information. Note that in non-supporting browsers, the position
+      of the popovers is broken.
     </p>
 
     <div id="submenu-1" popover="auto">

--- a/popover-api/popover-hint/index.html
+++ b/popover-api/popover-hint/index.html
@@ -33,6 +33,17 @@
       </section>
     </div>
 
+    <p class="help-para">
+      Press the buttons to show the auto popovers. Hover or focus the buttons to
+      show the hint popovers. Note how, when an auto popover is shown, you can
+      show the hint popovers without hiding it. See
+      <a
+        href="https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using#using_hint_popover_state"
+        >Using "hint" popover state</a
+      >
+      for more information.
+    </p>
+
     <div id="submenu-1" popover="auto">
       <button>Option A</button><br /><button>Option B</button>
     </div>

--- a/popover-api/popover-hint/index.js
+++ b/popover-api/popover-hint/index.js
@@ -1,0 +1,24 @@
+const tooltips = document.querySelectorAll(".tooltip");
+const btns = document.querySelectorAll("#button-bar button");
+
+function addEventListeners(i) {
+  btns[i].addEventListener("mouseover", () => {
+    tooltips[i].showPopover();
+  });
+
+  btns[i].addEventListener("mouseout", () => {
+    tooltips[i].hidePopover();
+  });
+
+  btns[i].addEventListener("focus", () => {
+    tooltips[i].showPopover();
+  });
+
+  btns[i].addEventListener("blur", () => {
+    tooltips[i].showPopover();
+  });
+}
+
+for (let i = 0; i < btns.length; i++) {
+  addEventListeners(i);
+}

--- a/popover-api/popover-hint/index.js
+++ b/popover-api/popover-hint/index.js
@@ -3,7 +3,7 @@ const btns = document.querySelectorAll("#button-bar button");
 
 function addEventListeners(i) {
   btns[i].addEventListener("mouseover", () => {
-    tooltips[i].showPopover();
+    tooltips[i].showPopover({ source: btns[i] });
   });
 
   btns[i].addEventListener("mouseout", () => {
@@ -11,7 +11,7 @@ function addEventListeners(i) {
   });
 
   btns[i].addEventListener("focus", () => {
-    tooltips[i].showPopover();
+    tooltips[i].showPopover({ source: btns[i] });
   });
 
   btns[i].addEventListener("blur", () => {

--- a/popover-api/popover-hint/index.js
+++ b/popover-api/popover-hint/index.js
@@ -15,7 +15,7 @@ function addEventListeners(i) {
   });
 
   btns[i].addEventListener("blur", () => {
-    tooltips[i].showPopover();
+    tooltips[i].hidePopover();
   });
 }
 


### PR DESCRIPTION
This PR adds a demo to demonstrate typical usage of the `popover="hint"` attribute value, which is supported in Chrome 133.