### PR TITLE
Fix | Prevent scrollbars on ViewTransitions MPA example

### DIFF
--- a/view-transitions/mpa/styles.css
+++ b/view-transitions/mpa/styles.css
@@ -12,8 +12,8 @@ body {
 
 img {
     display: block;
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
     object-fit: cover;
 }
 

--- a/view-transitions/mpa/styles.css
+++ b/view-transitions/mpa/styles.css
@@ -11,6 +11,7 @@ body {
 }
 
 img {
+    display: block;
     width: 100vw;
     height: 100vh;
     object-fit: cover;


### PR DESCRIPTION
## The Problem

Scrollbars appearing on on the ViewTransitions MPA example.

![image](https://github.com/user-attachments/assets/9b0614ce-b115-4153-b872-ed99cd871bad)

I don't believe this was intended.

## The Solution

Added `display: block` to the `img` element. The bug was occurring due to the way whitespace is rendered with inline elements. Changing to `display: block` sidesteps this issue. The images are still full screen, and there is no additional scroll and no scrollbars. 

![image](https://github.com/user-attachments/assets/ba4be436-73bd-4b32-bf38-435f7ed392cf)
