### PR TITLE
Fix broken non-support behavior in FileSystemObserver example

### DIFF
--- a/filesystemobserver/random.js
+++ b/filesystemobserver/random.js
@@ -1,10 +1,10 @@
 (async () => {
   const rootHandle = await navigator.storage.getDirectory();
-  await rootHandle.remove({ recursive: true });
   await startObserver();
 
   async function startObserver() {
     if ("FileSystemObserver" in self) {
+      await rootHandle.remove({ recursive: true });
       await import("./observer.js");
       demoOPFS();
     } else {


### PR DESCRIPTION
As explained in https://github.com/mdn/dom-examples/issues/298, the `FileSystemObserver` demo is meant to fail gracefully on browsers that don't support `FileSystemObserver` with a helpful message.

However, the message never gets shown on non-supporting browsers like Firefox and Safari because they also don't support the `remove()` method, which gets run outside the `FileSystemObserver` test structure.

This PR fixes the problem by moving the line that invokes `remove()` inside the test structure as well.

Fixes https://github.com/mdn/dom-examples/issues/298