### PR TITLE
[web-speech-api] Fixes speech utterance not stopping on reload in Chromium browsers

### DIFF
--- a/web-speech-api/speak-easy-synthesis/script.js
+++ b/web-speech-api/speak-easy-synthesis/script.js
@@ -100,3 +100,9 @@ rate.onchange = function () {
 voiceSelect.onchange = function () {
   speak();
 };
+
+window.addEventListener('beforeunload', (event) => {
+  if (synth.speaking) {
+    synth.cancel();
+  }
+});


### PR DESCRIPTION
Description: In the speech synthesis example at https://mdn.github.io/dom-examples/web-speech-api/speak-easy-synthesis/, the speech playback stops upon reloading the page in Firefox, but not in Chromium-based browsers (Brave, Edge, etc). The only way to stop the playback midway in Chromium is to close the tab or the browser itself. This inconsistency can be avoided by explicitly calling the [speechSynthesis.cancel() method](https://webaudio.github.io/web-speech-api/#tts-methods) every time a window is closed or reloaded.