### PR TITLE
Improve output buffer name in WebGPU compute demo

### DIFF
--- a/webgpu-compute-demo/script.js
+++ b/webgpu-compute-demo/script.js
@@ -1,5 +1,5 @@
 // Define global buffer size
-const BUFFER_SIZE = 1000; 
+const BUFFER_SIZE = 1000;
 
 // Compute shader
 const shader = `
@@ -29,65 +29,68 @@ fn main(
 async function init() {
   // 1: request adapter and device
   if (!navigator.gpu) {
-    throw Error('WebGPU not supported.');
+    throw Error("WebGPU not supported.");
   }
 
   const adapter = await navigator.gpu.requestAdapter();
   if (!adapter) {
-    throw Error('Couldn\'t request WebGPU adapter.');
+    throw Error("Couldn't request WebGPU adapter.");
   }
 
   const device = await adapter.requestDevice();
 
   // 2: Create a shader module from the shader template literal
   const shaderModule = device.createShaderModule({
-    code: shader
+    code: shader,
   });
 
   // 3: Create an output buffer to read GPU calculations to, and a staging buffer to be mapped for JavaScript access
 
-  const output = device.createBuffer({
+  const outputBuffer = device.createBuffer({
     size: BUFFER_SIZE,
-    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
   });
 
   const stagingBuffer = device.createBuffer({
     size: BUFFER_SIZE,
-    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST
+    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
   });
 
   // 4: Create a GPUBindGroupLayout to define the bind group structure, create a GPUBindGroup from it,
   // then use it to create a GPUComputePipeline
 
-  const bindGroupLayout =
-  device.createBindGroupLayout({
-    entries: [{
-      binding: 0,
-      visibility: GPUShaderStage.COMPUTE,
-      buffer: {
-        type: "storage"
-      }
-    }]
+  const bindGroupLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: {
+          type: "storage",
+        },
+      },
+    ],
   });
 
   const bindGroup = device.createBindGroup({
     layout: bindGroupLayout,
-    entries: [{
-      binding: 0,
-      resource: {
-        buffer: output,
-      }
-    }]
+    entries: [
+      {
+        binding: 0,
+        resource: {
+          buffer: outputBuffer,
+        },
+      },
+    ],
   });
 
   const computePipeline = device.createComputePipeline({
     layout: device.createPipelineLayout({
-      bindGroupLayouts: [bindGroupLayout]
+      bindGroupLayouts: [bindGroupLayout],
     }),
     compute: {
       module: shaderModule,
-      entryPoint: 'main'
-    }
+      entryPoint: "main",
+    },
   });
 
   // 5: Create GPUCommandEncoder to issue commands to the GPU
@@ -95,7 +98,7 @@ async function init() {
 
   // 6: Initiate render pass
   const passEncoder = commandEncoder.beginComputePass();
-    
+
   // 7: Issue commands
   passEncoder.setPipeline(computePipeline);
   passEncoder.setBindGroup(0, bindGroup);
@@ -106,7 +109,7 @@ async function init() {
 
   // Copy output buffer to staging buffer
   commandEncoder.copyBufferToBuffer(
-    output,
+    outputBuffer,
     0, // Source offset
     stagingBuffer,
     0, // Destination offset


### PR DESCRIPTION
This PR updates the name of the `output` buffer in the WebGPU compute demo to `outputBuffer`, as per the content change at https://github.com/mdn/content/pull/39732#discussion_r2120249761.