### PR TITLE
Add view-transition-name: match-element demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "web-storage" directory contains a basic demo to show usage of the Web Storage API. For more detail on how it works, read [Using the Web Storage API](https://developer.mozilla.org/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API). [View the demo live](https://mdn.github.io/dom-examples/web-storage/).
 
-- The "view-transitions" directory contains demos to show usage of the [View Transitions API](https://developer.mozilla.org/docs/Web/API/View_Transitions_API), both for single-page app [View the SPA demo live](https://mdn.github.io/dom-examples/view-transitions/spa/) and multiple-page app [View the MPA demo live](https://mdn.github.io/dom-examples/view-transitions/mpa/) view transitions.
+- The "view-transitions" directory contains demos to show usage of the [View Transitions API](https://developer.mozilla.org/docs/Web/API/View_Transitions_API), for single-page app ([View the SPA demo live](https://mdn.github.io/dom-examples/view-transitions/spa/)) and multiple-page app ([View the MPA demo live](https://mdn.github.io/dom-examples/view-transitions/mpa/)) view transitions. We've also included a demo to demonstrate the effect of the `view-transition-name` property `match-element` value ([View the `match-element` demo live](https://mdn.github.io/dom-examples/view-transitions/match-element/)).
 
 - The "web-share" directory contains a basic demo to show usage of the [Web Share API](https://developer.mozilla.org/docs/Web/API/Navigator/share). [View the demo live](https://mdn.github.io/dom-examples/web-share/).
 

--- a/view-transitions/match-element/index.html
+++ b/view-transitions/match-element/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>View Transitions match-element demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <script src="script.js" defer></script>
+  </head>
+  <body>
+    <h1>View Transitions match-element demo</h1>
+    <main class="match-element-applied">
+      <ul>
+        <li>
+          <h2><a href="#">One</a></h2>
+
+          <p class="summary">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent
+            volutpat tristique urna, eget tincidunt nunc pulvinar sit amet.
+            Maecenas quis enim ut enim rutrum sagittis a nec eros.
+          </p>
+
+          <p class="body-text">
+            Suspendisse id massa tellus. Donec interdum rutrum libero tincidunt
+            consectetur. Cras neque purus, sodales nec semper quis, iaculis a
+            nibh. Duis pulvinar nulla sit amet fringilla scelerisque. Vivamus
+            efficitur dictum mauris tristique auctor. Mauris quis tortor eu nisi
+            ornare dapibus. Praesent porttitor augue eget lobortis maximus.
+            Quisque in erat non ligula tempus tristique eu non magna.
+            Pellentesque nec vestibulum quam, sed tincidunt nibh. Donec quis
+            porta metus.
+          </p>
+        </li>
+        <li>
+          <h2><a href="#">Two</a></h2>
+          <p class="summary">
+            Mauris efficitur mi vel ipsum scelerisque, et fringilla est
+            efficitur. Sed varius egestas sem, sed dignissim magna ullamcorper
+            ultrices. Morbi at viverra magna, vitae auctor urna.
+          </p>
+
+          <p class="body-text">
+            Sed tempor et dui in varius. Sed justo sapien, ultricies id augue
+            in, viverra hendrerit nulla. Nunc tempor ex sed ex dictum lacinia.
+            Donec euismod felis at mi lobortis, id facilisis dolor faucibus.
+            Nulla facilisis vulputate quam semper pharetra. Aenean viverra at
+            turpis et gravida. Morbi vitae nisi metus. Ut at elit vitae augue
+            tristique luctus id eget libero. Nam tempor nunc id dui porta
+            molestie. Duis egestas orci nunc, vel lacinia leo dictum in. Ut orci
+            erat, ultricies in aliquet vitae, laoreet ac nulla. Duis pretium
+            fringilla lectus, nec bibendum nisl. Nam cursus libero eu tellus
+            luctus efficitur.
+          </p>
+        </li>
+        <li>
+          <h2><a href="#">Three</a></h2>
+          <p class="summary">
+            Ut et justo a lacus vulputate feugiat vitae in quam. Ut auctor lacus
+            nec erat tincidunt lobortis. Duis accumsan quis ipsum ac varius. Sed
+            sodales laoreet leo nec pretium.
+          </p>
+
+          <p class="body-text">
+            Suspendisse ac risus ac ligula semper convallis. Morbi feugiat
+            elementum odio. Pellentesque pulvinar suscipit mattis. Phasellus
+            rhoncus tempus justo, feugiat posuere ipsum rhoncus in. Ut at
+            ultricies nunc. Duis sem orci, gravida sit amet interdum vel,
+            vulputate quis eros. Pellentesque a tempor quam. Morbi eu lacinia
+            velit. Praesent pretium, ipsum nec pretium ornare, arcu metus
+            pellentesque elit, vel hendrerit arcu felis eu diam.
+          </p>
+        </li>
+
+        <li>
+          <h2><a href="#">Four</a></h2>
+          <p class="summary">
+            Morbi eu lacinia velit. Praesent pretium, ipsum nec pretium ornare,
+            arcu metus pellentesque elit, vel hendrerit arcu felis eu diam.
+          </p>
+
+          <p class="body-text">
+            Ut et justo a lacus vulputate feugiat vitae in quam. Ut auctor lacus
+            nec erat tincidunt lobortis. Duis accumsan quis ipsum ac varius. Sed
+            sodales laoreet leo nec pretium. Suspendisse ac risus ac ligula
+            semper convallis. Morbi feugiat elementum odio. Pellentesque
+            pulvinar suscipit mattis. Phasellus rhoncus tempus justo, feugiat
+            posuere ipsum rhoncus in. Ut at ultricies nunc. Duis sem orci,
+            gravida sit amet interdum vel, vulputate quis eros. Pellentesque a
+            tempor quam. Morbi eu lacinia velit. Praesent pretium, ipsum nec
+            pretium ornare, arcu metus pellentesque elit, vel hendrerit arcu
+            felis eu diam.
+          </p>
+        </li>
+      </ul>
+      <article></article>
+    </main>
+    <form>
+      <label for="match-element-checkbox"
+        >Apply <code>view-transition-name: match-element</code> to list
+        items?</label
+      >
+      <input type="checkbox" checked id="match-element-checkbox" />
+    </form>
+  </body>
+</html>

--- a/view-transitions/match-element/script.js
+++ b/view-transitions/match-element/script.js
@@ -1,0 +1,41 @@
+const mainElem = document.querySelector("main");
+let prevElem;
+let checkboxElem = document.querySelector("input");
+
+// View transition code
+
+function updateActiveItem(event) {
+  const clickedElem = event.target.parentElement.parentElement;
+
+  clickedElem.className = "active-item";
+
+  if (prevElem === clickedElem) {
+    prevElem.className = "";
+    prevElem = undefined;
+  } else if (prevElem) {
+    prevElem.className = "";
+    prevElem = clickedElem;
+  } else {
+    prevElem = clickedElem;
+  }
+}
+
+mainElem.addEventListener("click", (event) => {
+  if (event.target.tagName !== "A") {
+    return;
+  }
+
+  if (!document.startViewTransition) {
+    updateActiveItem(event);
+  } else {
+    const transition = document.startViewTransition(() =>
+      updateActiveItem(event)
+    );
+  }
+});
+
+// Update class on main to control whether match-element is applied
+
+checkboxElem.addEventListener("change", () => {
+  mainElem.classList.toggle("match-element-applied");
+});

--- a/view-transitions/match-element/style.css
+++ b/view-transitions/match-element/style.css
@@ -1,0 +1,145 @@
+/* General styling */
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  height: inherit;
+}
+
+h1 {
+  text-align: center;
+  margin: 0;
+  height: 80px;
+  line-height: 80px;
+}
+
+h2 {
+  margin: 0;
+}
+
+ul {
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+}
+
+li {
+  overflow: hidden;
+}
+
+li .summary {
+  font-weight: bold;
+}
+
+li .body-text {
+  display: none;
+}
+
+li.active-item .body-text {
+  display: block;
+}
+
+li:nth-child(1) {
+  background-color: #cbc0d3;
+  border: 20px solid #cbc0d3;
+}
+
+li:nth-child(2) {
+  background-color: #efd3d7;
+  border: 20px solid #efd3d7;
+}
+
+li:nth-child(3) {
+  background-color: #feeafa;
+  border: 20px solid #feeafa;
+}
+
+li:nth-child(4) {
+  background-color: #dee2ff;
+  border: 20px solid #dee2ff;
+}
+
+/* Links */
+
+a {
+  text-decoration: none;
+  color: rgb(0 0 255 / 0.8);
+}
+
+a:hover,
+a:focus {
+  color: rgb(100 100 255);
+}
+
+/* Layout */
+
+main {
+  height: calc(100% - 80px);
+  display: flex;
+  gap: 10px;
+  position: relative;
+}
+
+ul {
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+article {
+  flex: 1;
+}
+
+li {
+  flex: 1;
+}
+
+/* form/checkbox styles */
+
+form {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  z-index: 2;
+  background-color: white;
+  padding: 10px;
+  border: 1px solid black;
+}
+
+/* UI update styles */
+
+.active-item {
+  position: absolute;
+  z-index: 1;
+  translate: 310px;
+  width: calc(100% - 310px);
+  height: 100%;
+}
+
+.match-element-applied li {
+  view-transition-name: match-element;
+}
+
+/* View Transitions CSS */
+
+/* Adjust view transition speed */
+
+::view-transition-group(*) {
+  animation-duration: 0.5s;
+}
+
+/* Work around the differences in aspect-ratio of the before and after snapshots */
+
+html::view-transition-old(*),
+html::view-transition-new(*) {
+  height: 100%;
+}


### PR DESCRIPTION
Chrome 137 supports the `view-transition-name` property's `match-element` value. See https://chromestatus.com/feature/5098745710247936.

I am about to document this new property on MDN, therefore I am adding a demo that illustrates the effect of the keyword to `dom-examples`.