### PR TITLE
Add CSS progress() function demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "css-painting" directory contains examples demonstrating the [CSS Painting API](https://developer.mozilla.org/docs/Web/API/CSS_Painting_API). See the [examples live](https://mdn.github.io/dom-examples/css-painting).
 
+- The "css-progress" directory contains an example demonstrating the [CSS `progress()` function](https://developer.mozilla.org/en-US/docs/Web/CSS/progress). See the [example live](https://mdn.github.io/dom-examples/css-progress).
+
 - The "device-posture-api" directory contains an example demonstrating how to use the [Device Posture API](https://developer.mozilla.org/docs/Web/API/Device_Posture_API). [Run the example live](https://mdn.github.io/dom-examples/device-posture-api/).
 
 - The "drag-and-drop" directory is for examples and demos of the [HTML Drag and Drop](https://developer.mozilla.org/docs/Web/API/HTML_Drag_and_Drop_API) standard.

--- a/css-progress/index.css
+++ b/css-progress/index.css
@@ -55,6 +55,12 @@ article {
   /* opacity: progress(var(--container-width), 320, 1200); */
 }
 
+.content h1,
+.content p {
+  background-color: rgb(255 255 255 / 0.5);
+  padding: 5px;
+}
+
 .credit {
   position: absolute;
   bottom: 20px;

--- a/css-progress/index.css
+++ b/css-progress/index.css
@@ -1,0 +1,65 @@
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  height: 100%;
+}
+
+body {
+  height: inherit;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+article {
+  position: relative;
+  min-width: 320px;
+  max-width: 1200px;
+  width: 70%;
+  height: 600px;
+  border: 3px solid black;
+}
+
+.progress {
+  width: calc((progress(var(--container-width), 320, 1200)) * 100%);
+  height: 4px;
+  background-color: red;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.background {
+  position: absolute;
+  inset: 0;
+  background-image: url(https://mdn.github.io/shared-assets/images/examples/wide-background.jpg);
+  background-position-x: calc(
+    progress(var(--container-width), 320, 1200) * 100%
+  );
+}
+
+.content {
+  position: absolute;
+  inset: 0;
+  padding: 20px;
+  background-color: rgb(
+    calc(255 * progress(var(--container-width), 320, 1200))
+      calc(255 * progress(var(--container-width), 320, 1200)) 255 / 0.5
+  );
+  opacity: calc((progress(var(--container-width), 320, 1200) / 2) + 0.5);
+
+  /* Works without calc */
+  /* opacity: progress(var(--container-width), 320, 1200); */
+}
+
+.credit {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  width: 300px;
+  font-size: 0.8rem;
+  margin: 0;
+}

--- a/css-progress/index.html
+++ b/css-progress/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>CSS progress() function demo</title>
+
+    <link href="index.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+  </head>
+  <body>
+    <article>
+      <section class="background"></section>
+      <section class="content">
+        <div class="progress"></div>
+        <h1>CSS <code>progress()</code> function demo</h1>
+        <p>
+          Increase your viewport width to see the visual change (works best on
+          desktop; the <code>progress()</code> function is supported in Chrome
+          138+).
+        </p>
+
+        <p class="credit">
+          Background image:
+          <a
+            href="https://unsplash.com/photos/city-buildings-near-body-of-water-under-cloudy-sky-o6k0ZH1eOwg"
+            >Hong Kong Island from aerial view in sunrise</a
+          >
+          from unsplash.com, taken by
+          <a href="https://unsplash.com/@yiucheung">Lok Yiu Cheung</a>.
+        </p>
+      </section>
+    </article>
+  </body>
+</html>

--- a/css-progress/index.js
+++ b/css-progress/index.js
@@ -1,0 +1,13 @@
+const articleElem = document.querySelector("article");
+
+function setContainerWidth() {
+  const clientRect = articleElem.getBoundingClientRect();
+  articleElem.style.setProperty(
+    "--container-width",
+    Math.floor(clientRect.width)
+  );
+}
+
+window.addEventListener("resize", setContainerWidth);
+
+setContainerWidth();


### PR DESCRIPTION
This PR adds a demo for the CSS progress() function.

I'm going to link to the demo in this case rather than include it on the page as a live example, because it needs a wide screen to really show off the effect I'm creating.

The reference `shared-assets` image is added in https://github.com/mdn/shared-assets/pull/52.