### PR TITLE
Add Navigation API demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "media" directory contains examples and demos showing how to use HTML and DOM [media elements and APIs](https://developer.mozilla.org/docs/Web/Media).
 
+- The "navigation-api" directory contains a basic demo to show off some of the features of the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API). [Run the demo live](https://mdn.github.io/dom-examples/navigation-api).
+
 - The "payment-request" directory contains examples of the [Payment Request API](https://developer.mozilla.org/docs/Web/API/Payment_Request_API).
 
 - The "pointerevents" directory is for examples and demos of the [Pointer Events](https://developer.mozilla.org/docs/Web/API/Pointer_events) standard.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "media" directory contains examples and demos showing how to use HTML and DOM [media elements and APIs](https://developer.mozilla.org/docs/Web/Media).
 
-- The "navigation-api" directory contains a basic demo to show off some of the features of the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API). [Run the demo live](https://mdn.github.io/dom-examples/navigation-api).
+- The "navigation-api" directory contains a basic demo to show off some of the features of the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API). [Run the demo live](https://mdn.github.io/dom-examples/navigation-api/).
 
 - The "payment-request" directory contains examples of the [Payment Request API](https://developer.mozilla.org/docs/Web/API/Payment_Request_API).
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "media" directory contains examples and demos showing how to use HTML and DOM [media elements and APIs](https://developer.mozilla.org/docs/Web/Media).
 
-- The "navigation-api" directory contains a basic demo to show off some of the features of the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API). [Run the demo live](https://mdn.github.io/dom-examples/navigation-api/).
+- The "navigation-api" directory contains a basic example that demonstrates some features of the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API). [Run the demo live](https://mdn.github.io/dom-examples/navigation-api/).
 
 - The "payment-request" directory contains examples of the [Payment Request API](https://developer.mozilla.org/docs/Web/API/Payment_Request_API).
 

--- a/navigation-api/index.html
+++ b/navigation-api/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/navigation-api/index.html
+++ b/navigation-api/index.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Navigation API demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>
+      <a href="https://github.com/WICG/navigation-api/">Navigation API</a> demo
+    </h1>
+
+    <main>
+      <p>
+        I am <code>index.html</code>! I contain a normal link to
+        <code>subpage.html</code>:
+      </p>
+
+      <p><a href="subpage.html">subpage.html</a></p>
+
+      <p>
+        This link works without JavaScript and in all browsers. If you
+        <kbd>Ctrl</kbd> click or middle-click or right-click to open in a new
+        tab, that will all work as usual.
+      </p>
+
+      <p>
+        But if you're using Chromium &geq;105, and just activate it without
+        trying to open it in a new window, then it will do a single-page app
+        navigation!
+      </p>
+
+      <p>
+        Here is another link, but it's a hash navigation, so it shouldn't get
+        intercepted. You can still watch the console to see what happens with
+        the <code>navigate</code> event:
+      </p>
+
+      <p><a href="#console">#console</a></p>
+
+      <p>
+        Here are some buttons for other tests; you can watch your console to see
+        what happens.
+      </p>
+
+      <p><button onclick="history.back()">history.back()</button></p>
+
+      <p><button onclick="location.reload()">location.reload()</button></p>
+
+      <p>
+        <button
+          onclick="setTimeout(() => location.href = 'subpage.html', 2_000)">
+          Go to subpage in 2 seconds
+        </button>
+      </p>
+    </main>
+
+    <div id="console"></div>
+
+    <label>
+      <input type="checkbox" id="cancel-navigation" />
+      Use event.preventDefault() to show a "please don't leave" dialog (Chromium
+      &geq;112.0.5613.0 for traversals)
+    </label>
+
+    <label>
+      <input type="checkbox" id="add-delay" />
+      Add an artificial two-second delay to all navigations (should impact the
+      loading spinner/scroll restoration/focus reset/accessibility
+      announcements).
+    </label>
+
+    <p>
+      (Note: loading spinner control does not yet work for back/forward
+      traversals; that's happening next.)
+    </p>
+
+    <footer>
+      <a href="https://github.com/mdn/dom-examples/tree/main/navigation-api"
+        >View source on GitHub</a
+      >
+    </footer>
+
+    <p>
+      <a href="https://example.com"
+        >example.com link for accessibility testing</a
+      >
+    </p>
+
+    <dialog id="are-you-sure">
+      <h2>Please don't leave this page</h2>
+
+      <p>I've canceled the navigation! Please don't leave!</p>
+
+      <p>
+        (You can still leave by changing the URL in the URL bar, or closing the
+        window, or using the back button twice in a row without clicking on the
+        page in between.)
+      </p>
+
+      <form method="dialog">
+        <input type="submit" value="OK" />
+      </form>
+    </dialog>
+
+    <script type="module">
+      const output = document.querySelector("#console");
+      window.addEventListener("error", (e) => {
+        output.textContent += e.error.message + "\n" + e.error.stack + "\n\n";
+      });
+    </script>
+
+    <script type="module">
+      const addDelay = document.querySelector("#add-delay");
+      const cancelNavigation = document.querySelector("#cancel-navigation");
+      const areYouSure = document.querySelector("#are-you-sure");
+
+      navigation.addEventListener("navigate", (e) => {
+        console.log(e);
+
+        if (!e.canIntercept || e.hashChange) {
+          return;
+        }
+
+        if (cancelNavigation.checked) {
+          if (!e.cancelable) {
+            console.log(
+              "Tried to cancel the navigation, but it was not cancelable. Maybe because of lack of user activation; maybe because of Chromium <112.0.5613.0 and traversal."
+            );
+          } else {
+            e.preventDefault();
+            areYouSure.showModal();
+            return;
+          }
+        }
+
+        e.intercept({
+          async handler() {
+            e.signal.addEventListener("abort", () => {
+              const newMain = document.createElement("main");
+              newMain.textContent =
+                "Navigation was aborted, potentially by the browser stop button!";
+              document.querySelector("main").replaceWith(newMain);
+            });
+
+            if (addDelay.checked) {
+              await delay(2_000, { signal: e.signal });
+            }
+
+            const body = await (
+              await fetch(e.destination.url, { signal: e.signal })
+            ).text();
+            const { title, main } = getResult(body);
+
+            document.title = title;
+            document.querySelector("main").replaceWith(main);
+          },
+        });
+      });
+
+      navigation.addEventListener("navigatesuccess", () => {
+        console.log("navigatesuccess");
+        areYouSure.close();
+      });
+      navigation.addEventListener("navigateerror", (ev) => {
+        console.log("navigateerror", ev.error);
+      });
+
+      function getResult(htmlString) {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(htmlString, "text/html");
+        return { title: doc.title, main: doc.querySelector("main") };
+      }
+
+      function delay(ms, { signal = null } = {}) {
+        signal?.throwIfAborted();
+        return new Promise((resolve, reject) => {
+          const id = setTimeout(resolve, ms);
+
+          signal.addEventListener("abort", () => {
+            clearTimeout(id);
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/navigation-api/style.css
+++ b/navigation-api/style.css
@@ -1,0 +1,65 @@
+:root {
+  font-family: -apple-system, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 0;
+  --root-padding: 24px;
+  padding: 0 var(--root-padding);
+  background: white;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+header {
+  margin-bottom: 1em;
+}
+
+main {
+  flex: 1;
+  border: 1px dashed blue;
+  padding: 1em;
+}
+
+footer {
+  text-align: center;
+  border-top: 1px solid gray;
+  margin: 30px calc(-1 * var(--root-padding)) 0;
+  padding: var(--root-padding);
+}
+
+h1,
+h2 {
+  line-height: 1.3em;
+  margin: 0.5rem 0 0.75rem;
+  font-weight: normal;
+}
+
+#console {
+  position: relative;
+  border: 1px solid gray;
+  border-radius: 4px;
+  padding: 0.5rem;
+  margin: 2em 0;
+  white-space: pre;
+  font-family: monospace;
+  min-height: 2rem;
+}
+
+#console::before {
+  content: "Error Console";
+  display: inline-block;
+  position: absolute;
+  top: 0;
+  left: 0.1em;
+  background: white;
+}
+
+:focus {
+  outline: 1px solid green;
+}

--- a/navigation-api/subpage.html
+++ b/navigation-api/subpage.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/navigation-api/subpage.html
+++ b/navigation-api/subpage.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Navigation API demo: subpage</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>
+      <a href="https://github.com/WICG/navigation-api/">Navigation API</a> demo
+    </h1>
+
+    <main>
+      <p>I am <code>subpage.html</code>!</p>
+
+      <p>
+        You can use either your browser back button, or the following link or
+        button, to go back to index.html. Either will perform a single-page
+        navigation, in browsers that support the navigation API!
+      </p>
+
+      <p><a href="/navigation-api/">Back to index.html</a>.</p>
+
+      <p><button onclick="history.back()">history.back()</button></p>
+    </main>
+
+    <p>
+      If you see this, you did a normal multi-page navigation, not a navigation
+      API-mediated single-page navigation.
+    </p>
+
+    <footer>
+      <a href="https://github.com/mdn/dom-examples/tree/main/navigation-api"
+        >View source on GitHub</a
+      >
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
The MDN [Navigation API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) has several pages that link to [this demo hosted on Glitch](https://gigantic-honored-octagon.glitch.me/).

Because Glitch is going away, this PR re-hosts the demo on the `dom-examples` repo.