### PR TITLE
fix: use ./ for path in example

### DIFF
--- a/url-params/index.html
+++ b/url-params/index.html
@@ -4,8 +4,8 @@
     <title>URL API demo | MDN Web Docs</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="/style.css" />
-    <script src="/script.js" defer></script>
+    <link rel="stylesheet" href="./style.css" />
+    <script src="./script.js" defer></script>
   </head>
   <body>
     <p>


### PR DESCRIPTION
Small one to fix broken resources at https://mdn.github.io/dom-examples/url-params/ seeing as the root is actually `mdn.github.io/{repo}`.