### PR TITLE
Add Local Font Access API demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "insert-adjacent" directory contains basic demos for [insertAdjacentElement](https://mdn.github.io/dom-examples/insert-adjacent/insertAdjacentElement.html) and [insertAdjacentText](https://mdn.github.io/dom-examples/insert-adjacent/insertAdjacentText.html).
 
-- The "launch-handler" directory contains a demo for the [Launch Handler API](https://developer.mozilla.org/en-US/docs/Web/API/Launch_Handler_API). [View the demo live](https://mdn.github.io/dom-examples/local-font-access/). This example was originally published on Glitch by [Thomas Steiner](https://front-end.social/@tomayac@toot.cafe).
+- The "launch-handler" directory contains a demo for the [Launch Handler API](https://developer.mozilla.org/en-US/docs/Web/API/Launch_Handler_API). [View the demo live](https://mdn.github.io/dom-examples/launch-handler/). This example was originally published on Glitch by [Thomas Steiner](https://front-end.social/@tomayac@toot.cafe).
 
-- The "local-font-access" directory contains a demo for the [Local Font Access API](https://developer.mozilla.org/en-US/docs/Web/API/Local_Font_Access_API). [View the demo live](https://mdn.github.io/dom-examples/launch-handler/).
+- The "local-font-access" directory contains a demo for the [Local Font Access API](https://developer.mozilla.org/en-US/docs/Web/API/Local_Font_Access_API). [View the demo live](https://mdn.github.io/dom-examples/local-font-access/).
 
 - The "matchmedia" directory contains a basic demo to test matchMedia functionality. See [Window.matchMedia](https://developer.mozilla.org/docs/Web/API/Window/matchMedia) for more details. [Run the demo live](https://mdn.github.io/dom-examples/matchmedia/).
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "insert-adjacent" directory contains basic demos for [insertAdjacentElement](https://mdn.github.io/dom-examples/insert-adjacent/insertAdjacentElement.html) and [insertAdjacentText](https://mdn.github.io/dom-examples/insert-adjacent/insertAdjacentText.html).
 
-- The "launch-handler" directory contains a demo for the [Launch Handler API](https://developer.mozilla.org/en-US/docs/Web/API/Launch_Handler_API). [View the demo live](https://mdn.github.io/dom-examples/launch-handler/). This example was originally published on Glitch by [Thomas Steiner](https://front-end.social/@tomayac@toot.cafe).
+- The "launch-handler" directory contains a demo for the [Launch Handler API](https://developer.mozilla.org/en-US/docs/Web/API/Launch_Handler_API). [View the demo live](https://mdn.github.io/dom-examples/local-font-access/). This example was originally published on Glitch by [Thomas Steiner](https://front-end.social/@tomayac@toot.cafe).
+
+- The "local-font-access" directory contains a demo for the [Local Font Access API](https://developer.mozilla.org/en-US/docs/Web/API/Local_Font_Access_API). [View the demo live](https://mdn.github.io/dom-examples/launch-handler/).
 
 - The "matchmedia" directory contains a basic demo to test matchMedia functionality. See [Window.matchMedia](https://developer.mozilla.org/docs/Web/API/Window/matchMedia) for more details. [Run the demo live](https://mdn.github.io/dom-examples/matchmedia/).
 

--- a/local-font-access/index.css
+++ b/local-font-access/index.css
@@ -1,0 +1,23 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  width: 500px;
+  margin: 2rem auto;
+}
+
+button,
+select {
+  padding: 5px;
+}
+
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  height: 100%;
+}
+
+.sample-text {
+  line-height: 1.5;
+  font-size: 2rem;
+}

--- a/local-font-access/index.html
+++ b/local-font-access/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Local Font Access API demo</title>
+
+    <link href="index.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+  </head>
+  <body>
+    <section>
+      <div class="start-button-container">
+        <button>Get your local fonts</button>
+      </div>
+      <div class="select-container">
+        <label for="font-select">Choose a local font:</label>
+        <select id="font-select"></select>
+      </div>
+    </section>
+
+    <p class="sample-text">
+      The quick brown fox jumps over the lazy dog. Jackdaws love my big sphinx
+      of quartz. Pack my box with five dozen liquor jugs.
+    </p>
+
+    <p>
+      This is a demo of the
+      <a
+        href="https://developer.mozilla.org/en-US/docs/Web/API/Local_Font_Access_API"
+        >Local Font Access API</a
+      >. Check out the
+      <a
+        href="https://github.com/chrisdavidmills/dom-examples/tree/main/local-font-access"
+        >source code</a
+      >.
+    </p>
+  </body>
+</html>

--- a/local-font-access/index.html
+++ b/local-font-access/index.html
@@ -31,7 +31,7 @@
         >Local Font Access API</a
       >. Check out the
       <a
-        href="https://github.com/chrisdavidmills/dom-examples/tree/main/local-font-access"
+        href="https://github.com/mdn/dom-examples/tree/main/local-font-access"
         >source code</a
       >.
     </p>

--- a/local-font-access/index.html
+++ b/local-font-access/index.html
@@ -8,6 +8,7 @@
     <script defer src="index.js"></script>
   </head>
   <body>
+    <h1>Local Font Access API demo</h1>
     <section>
       <div class="start-button-container">
         <button>Get your local fonts</button>

--- a/local-font-access/index.html
+++ b/local-font-access/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/local-font-access/index.js
+++ b/local-font-access/index.js
@@ -8,7 +8,7 @@ const sampleText = document.querySelector(".sample-text");
 selectElemContainer.style.display = "none";
 
 async function populatefonts() {
-  startButton.textContent = "Fetching fonts...";
+  startButton.textContent = "Fetching local fonts...";
   startButton.disabled = true;
 
   try {

--- a/local-font-access/index.js
+++ b/local-font-access/index.js
@@ -1,0 +1,38 @@
+const selectElem = document.querySelector("select");
+const selectElemContainer = document.querySelector(".select-container");
+const startButton = document.querySelector("button");
+const startButtonContainer = document.querySelector(".start-button-container");
+
+const sampleText = document.querySelector(".sample-text");
+
+selectElemContainer.style.display = "none";
+
+async function populatefonts() {
+  startButton.textContent = "Fetching fonts...";
+  startButton.disabled = true;
+
+  try {
+    const availableFonts = await window.queryLocalFonts();
+    console.log(availableFonts);
+    for (const fontData of availableFonts) {
+      selectElem.innerHTML += `<option value="${fontData.family}">${fontData.fullName}</option>`;
+    }
+
+    selectElemContainer.style.display = "block";
+    startButtonContainer.style.display = "none";
+    selectElem.selectedIndex = 0;
+
+    selectElem.addEventListener("change", applyFont);
+    applyFont();
+  } catch (err) {
+    console.error(err.name, err.message);
+    startButton.textContent = "Get your local fonts";
+    startButton.disabled = false;
+  }
+}
+
+function applyFont() {
+  sampleText.style.fontFamily = selectElem.value;
+}
+
+startButton.addEventListener("click", populatefonts);


### PR DESCRIPTION
The MDN [Local Font Access API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Local_Font_Access_API) has several pages that link to [this demo hosted on Glitch](https://local-font-access.glitch.me/demo/).

Because Glitch is going away, and the linked demo above doesn't work, I've decided to create my own simple version of it, which is added in this PR.

Note that the Local Font Access API requires HTTPS. It won't work if you test it on localhost. Ironically, I ended up testing it in Glitch, as it is still around for a few more days: https://cat-judicious-hose.glitch.me/ ;-)