### PR TITLE
Add requestvideoframecallback demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "reporting-api" directory contains a couple of basic demos to show usage of the Reporting API. You can find more explanation of how the API works in the main MDN [Reporting API](https://developer.mozilla.org/docs/Web/API/Reporting_API) docs. [Run the deprecation report demo live](https://mdn.github.io/dom-examples/reporting-api/deprecation_report.html).
 
+- The "requestvideoframecallback" directory contains an example that demonstrates the [requestVideoFrameCallback() method](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback). [View the demo live](https://mdn.github.io/dom-examples/requestvideoframecallback/).
+
 - The "resize-event" directory contains a basic demo to show how you can use the [resize event](https://developer.mozilla.org/docs/Web/API/Window/resize_event). Resize the browser window either by height or width to see the size of your current window. [Run the demo live](https://mdn.github.io/dom-examples/resize-event).
 
 - The "screen-capture-api" directory contains demos to show typical usage of the [Screen Capture API](https://developer.mozilla.org/docs/Web/API/Screen_Capture_API) and [Screen Capture Extensions](https://developer.mozilla.org/docs/Web/API/Screen_Capture_extensions).

--- a/requestvideoframecallback/index.html
+++ b/requestvideoframecallback/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>requestVideoFrameCallback demo</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- import the webpage's stylesheet -->
+    <link rel="stylesheet" href="main.css" />
+
+    <!-- import the webpage's javascript file -->
+    <script src="main.js" defer></script>
+  </head>
+  <body>
+    <h1><code>requestVideoFrameCallback</code> demo</h1>
+    <p>
+      Start <button type="button">⏯</button> playing the video. Pause the video to read the metadata.
+      Drawing video frames on the canvas is synced with the actual video framerate.
+      For details, check out the blog post
+      <a href="https://web.dev/articles/requestvideoframecallback-rvfc">
+        Perform efficient per-video-frame operations on video with requestVideoFrameCallback()</a>; also see the demo <a href="https://github.com/mdn/dom-examples/tree/main/requestvideoframecallback">source code</a>.
+    </p>
+    <video width="640" height="360" controls playsinline></video>
+    <canvas width="640" height="360"></canvas>
+    <p><span id="fps-info">0</span>fps</p>
+    <p><pre id="metadata-info"></pre></p>
+  </body>
+</html>

--- a/requestvideoframecallback/main.css
+++ b/requestvideoframecallback/main.css
@@ -1,0 +1,15 @@
+body {
+  font-family: helvetica, arial, sans-serif;
+  margin: 2em;
+}
+
+h1 {
+  font-style: italic;
+  color: #373fff;
+}
+
+video,
+canvas {
+  max-width: 100%;
+  height: auto;
+}

--- a/requestvideoframecallback/main.js
+++ b/requestvideoframecallback/main.js
@@ -1,0 +1,46 @@
+const startDrawing = () => {
+  const button = document.querySelector("button");
+  const video = document.querySelector("video");
+  const canvas = document.querySelector("canvas");
+  const ctx = canvas.getContext("2d");
+  const fpsInfo = document.querySelector("#fps-info");
+  const metadataInfo = document.querySelector("#metadata-info");
+
+  button.addEventListener("click", () =>
+    video.paused ? video.play() : video.pause()
+  );
+
+  video.addEventListener("play", () => {
+    if (!("requestVideoFrameCallback" in HTMLVideoElement.prototype)) {
+      return alert(
+        "Your browser does not support the `Video.requestVideoFrameCallback()` API."
+      );
+    }
+  });
+
+  let width = canvas.width;
+  let height = canvas.height;
+
+  let paintCount = 0;
+  let startTime = 0.0;
+
+  const updateCanvas = (now, metadata) => {
+    if (startTime === 0.0) {
+      startTime = now;
+    }
+
+    ctx.drawImage(video, 0, 0, width, height);
+
+    const elapsed = (now - startTime) / 1000.0;
+    const fps = (++paintCount / elapsed).toFixed(3);
+    fpsInfo.innerText = !isFinite(fps) ? 0 : fps;
+    metadataInfo.innerText = JSON.stringify(metadata, null, 2);
+
+    video.requestVideoFrameCallback(updateCanvas);
+  };
+
+  video.src = "assets/bigbuckbunny.mp4";
+  video.requestVideoFrameCallback(updateCanvas);
+};
+
+window.addEventListener("load", startDrawing);


### PR DESCRIPTION
The MDN [requestVideoFrameCallback() documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback) links to [this demo hosted on Glitch](https://requestvideoframecallback.glitch.me/).

Because Glitch is going away, this PR re-hosts the demo on the `dom-examples` repo.