### PR TITLE
Add CSS custom functions examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "contact-picker" directory contains an example showing usage of the [Contact Picker API](https://developer.mozilla.org/en-US/docs/Web/API/Contact_Picker_API). [See the example live](https://mdn.github.io/dom-examples/contact-picker/).
 
-- The "css-carousels" directory contains two examples showing how to use the CSS Carousel features — [a basic example featuring scroll buttons and scroll markers](https://mdn.github.io/dom-examples/css-carousels/scroll-button-scroll-marker/), and an [example that also uses the `::columns` pseudo-class to paginate the content](https://mdn.github.io/dom-examples/css-carousels/scroll-button-scroll-marker-with-columns/).
+- The "css-carousels" directory contains two examples showing how to use the CSS Carousel features — [a set of color adjustment functions](https://mdn.github.io/dom-examples/css-carousels/color-adjust-functions/), a [complex gradient background function](https://mdn.github.io/dom-examples/css-carousels/gradient-function/), and a [responsive narrow/wide value selection function](https://mdn.github.io/dom-examples/css-carousels/responsive-narrow-wide/).
+
+- The "css-custom-functions" directory contains three examples showing how to use CSS custom functions — [a basic example featuring scroll buttons and scroll markers](https://mdn.github.io/dom-examples/css-carousels/scroll-button-scroll-marker/), and an [example that also uses the `::columns` pseudo-class to paginate the content](https://mdn.github.io/dom-examples/css-carousels/scroll-button-scroll-marker-with-columns/).
 
 - The "css-painting" directory contains examples demonstrating the [CSS Painting API](https://developer.mozilla.org/docs/Web/API/CSS_Painting_API). See the [examples live](https://mdn.github.io/dom-examples/css-painting).
 

--- a/css-custom-functions/color-adjust-functions/index.html
+++ b/css-custom-functions/color-adjust-functions/index.html
@@ -6,6 +6,12 @@
     <link href="style.css" rel="stylesheet" />
   </head>
   <body>
+    <p class="support">
+      ⚠️ Your browser doesn't currently support
+      <a href="https://drafts.csswg.org/css-mixins-1/#defining-custom-functions"
+        >CSS custom functions</a
+      >.
+    </p>
     <section>
       <h2>Color adjust functions</h2>
       <p>

--- a/css-custom-functions/color-adjust-functions/index.html
+++ b/css-custom-functions/color-adjust-functions/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Color adjust functions</title>
+    <link href="style.css" rel="stylesheet" />
+  </head>
+  <body>
+    <section>
+      <h2>Color adjust functions</h2>
+      <p>
+        This example features a set of color adjust functions that return a
+        semi-transparent version of a given color, a lighter version of the
+        color, or a darker version of the color.
+      </p>
+    </section>
+  </body>
+</html>

--- a/css-custom-functions/color-adjust-functions/style.css
+++ b/css-custom-functions/color-adjust-functions/style.css
@@ -1,0 +1,50 @@
+/* Borrowed from Miriam Suzanne's custom CSS functions post
+   https://www.oddbird.net/2025/04/11/custom-functions/  */
+@function --transparent(--color <color>, --alpha <number>: 0.8) {
+  result: oklch(from var(--color) l c h / var(--alpha));
+}
+
+@function --lighter(--color <color>, --lightness-adjust <number>: 0.2) {
+  result: oklch(from var(--color) calc(l + var(--lightness-adjust)) c h);
+}
+
+@function --darker(--color <color>, --lightness-adjust <number>: 0.2) {
+  result: oklch(from var(--color) calc(l - var(--lightness-adjust)) c h);
+}
+
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  height: inherit;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent 0 20px,
+    black 20px 40px
+  );
+}
+
+section {
+  width: 50%;
+  padding: 0 20px;
+  border-radius: 20px;
+  --base-color: #faa6ff;
+  background-color: --transparent(var(--base-color));
+  border: 3px solid --lighter(var(--base-color), 0.1);
+  color: --darker(var(--base-color), 0.55);
+}
+
+h2 {
+  font-size: 2rem;
+}
+
+p {
+  font-size: 1.4rem;
+  line-height: 1.5;
+}

--- a/css-custom-functions/color-adjust-functions/style.css
+++ b/css-custom-functions/color-adjust-functions/style.css
@@ -1,14 +1,16 @@
 /* Borrowed from Miriam Suzanne's custom CSS functions post
    https://www.oddbird.net/2025/04/11/custom-functions/  */
-@function --transparent(--color <color>, --alpha <number>: 0.8) {
+@function --transparent(--color <color>, --alpha <number>: 0.8) returns <color> {
   result: oklch(from var(--color) l c h / var(--alpha));
 }
 
-@function --lighter(--color <color>, --lightness-adjust <number>: 0.2) {
+@function --lighter(--color <color>, --lightness-adjust <number>: 0.2) returns
+  <color> {
   result: oklch(from var(--color) calc(l + var(--lightness-adjust)) c h);
 }
 
-@function --darker(--color <color>, --lightness-adjust <number>: 0.2) {
+@function --darker(--color <color>, --lightness-adjust <number>: 0.2) returns
+  <color> {
   result: oklch(from var(--color) calc(l - var(--lightness-adjust)) c h);
 }
 

--- a/css-custom-functions/color-adjust-functions/style.css
+++ b/css-custom-functions/color-adjust-functions/style.css
@@ -28,7 +28,7 @@ body {
   background-image: repeating-linear-gradient(
     -45deg,
     transparent 0 20px,
-    black 20px 40px
+    lightgrey 20px 40px
   );
 }
 

--- a/css-custom-functions/color-adjust-functions/style.css
+++ b/css-custom-functions/color-adjust-functions/style.css
@@ -14,8 +14,14 @@
   result: oklch(from var(--color) calc(l - var(--lightness-adjust)) c h);
 }
 
+/* Function that returns a value of none to hide a "not supported" banner
+if CSS custom functions are supported. If not, the banner will show. */
+@function --supports() {
+  result: none;
+}
+
 html {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: system-ui;
   height: 100%;
 }
 
@@ -49,4 +55,16 @@ h2 {
 p {
   font-size: 1.4rem;
   line-height: 1.5;
+}
+
+/* Styling for the support banner */
+.support {
+  border-radius: 0;
+  border: 6px dashed black;
+  background-color: #fef0c3;
+  font-size: 1.3rem;
+  padding: 1rem;
+  position: absolute;
+  inset: 25%;
+  display: --supports();
 }

--- a/css-custom-functions/gradient-function/index.html
+++ b/css-custom-functions/gradient-function/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Color adjust functions</title>
+    <link href="style.css" rel="stylesheet" />
+  </head>
+  <body>
+    <section id="one">
+      <h2>Gradient generator function</h2>
+      <p>
+        This example includes a function that defines a specific background
+        repeating radial gradient. It is useful because it defines the complex
+        code in one place, and then allows you to create a background of this type wherever
+        needed with a function call that just requires you to specify
+        some arguments to define the size and color.
+      </p>
+    </section>
+    <section id="two"></section>
+    <section id="three"></section>
+  </body>
+</html>

--- a/css-custom-functions/gradient-function/index.html
+++ b/css-custom-functions/gradient-function/index.html
@@ -6,14 +6,20 @@
     <link href="style.css" rel="stylesheet" />
   </head>
   <body>
+    <p class="support">
+      ⚠️ Your browser doesn't currently support
+      <a href="https://drafts.csswg.org/css-mixins-1/#defining-custom-functions"
+        >CSS custom functions</a
+      >.
+    </p>
     <section id="one">
       <h2>Gradient generator function</h2>
       <p>
         This example includes a function that defines a specific background
         repeating radial gradient. It is useful because it defines the complex
-        code in one place, and then allows you to create a background of this type wherever
-        needed with a function call that just requires you to specify
-        some arguments to define the size and color.
+        code in one place, and then allows you to create a background of this
+        type wherever needed with a function call that just requires you to
+        specify some arguments to define the size and color.
       </p>
     </section>
     <section id="two"></section>

--- a/css-custom-functions/gradient-function/style.css
+++ b/css-custom-functions/gradient-function/style.css
@@ -1,9 +1,17 @@
 /* CSS gradient code adapted from the Shippo pattern in Lea Verou's
 CSS3 patterns gallery: https://projects.verou.me/css3patterns/#shippo */
 @function --shippo-pattern(--size <length>, --tint <color>) {
-  result: 
-    radial-gradient(closest-side, transparent 98%, rgba(0 0 0 / 0.3) 99%) 0 0 / var(--size) var(--size),
-    radial-gradient(closest-side, transparent 98%, rgba(0 0 0 / 0.3) 99%) calc(var(--size)/2) calc(var(--size)/2) / var(--size) var(--size) var(--tint);
+  result: radial-gradient(closest-side, transparent 98%, rgba(0 0 0 / 0.3) 99%)
+      0 0 / var(--size) var(--size),
+    radial-gradient(closest-side, transparent 98%, rgba(0 0 0 / 0.3) 99%)
+      calc(var(--size) / 2) calc(var(--size) / 2) / var(--size) var(--size)
+      var(--tint);
+}
+
+/* Function that returns a value of none to hide a "not supported" banner
+if CSS custom functions are supported. If not, the banner will show. */
+@function --supports() {
+  result: none;
 }
 
 * {
@@ -11,7 +19,7 @@ CSS3 patterns gallery: https://projects.verou.me/css3patterns/#shippo */
 }
 
 html {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: system-ui;
   height: 100%;
 }
 
@@ -30,7 +38,8 @@ section {
   border: 1px solid black;
 }
 
-h2, p {
+h2,
+p {
   padding: 0.5rem;
   border-radius: 10px;
   background-color: rgb(255 255 255 / 80%);
@@ -54,4 +63,16 @@ p {
 
 #three {
   background: --shippo-pattern(10vw, purple);
+}
+
+/* Styling for the support banner */
+.support {
+  border-radius: 0;
+  border: 6px dashed black;
+  background-color: #fef0c3;
+  font-size: 1.3rem;
+  padding: 1rem;
+  position: absolute;
+  inset: 25%;
+  display: --supports();
 }

--- a/css-custom-functions/gradient-function/style.css
+++ b/css-custom-functions/gradient-function/style.css
@@ -30,6 +30,11 @@ section {
   border: 1px solid black;
 }
 
+h2, p {
+  padding: 0.5rem;
+  border-radius: 10px;
+  background-color: rgb(255 255 255 / 80%);
+}
 h2 {
   font-size: 1.5rem;
 }

--- a/css-custom-functions/gradient-function/style.css
+++ b/css-custom-functions/gradient-function/style.css
@@ -1,0 +1,52 @@
+/* CSS gradient code adapted from the Shippo pattern in Lea Verou's
+CSS3 patterns gallery: https://projects.verou.me/css3patterns/#shippo */
+@function --shippo-pattern(--size <length>, --tint <color>) {
+  result: 
+    radial-gradient(closest-side, transparent 98%, rgba(0 0 0 / 0.3) 99%) 0 0 / var(--size) var(--size),
+    radial-gradient(closest-side, transparent 98%, rgba(0 0 0 / 0.3) 99%) calc(var(--size)/2) calc(var(--size)/2) / var(--size) var(--size) var(--tint);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: Arial, Helvetica, sans-serif;
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 20px;
+  height: inherit;
+  display: flex;
+  gap: 20px;
+}
+
+section {
+  border-radius: 20px;
+  flex: 1;
+  padding: 0 20px;
+  border: 1px solid black;
+}
+
+h2 {
+  font-size: 1.5rem;
+}
+
+p {
+  font-size: 1.1rem;
+  line-height: 1.5;
+}
+
+#one {
+  background: --shippo-pattern(100px, #def);
+}
+
+#two {
+  background: --shippo-pattern(3.5rem, lime);
+}
+
+#three {
+  background: --shippo-pattern(10vw, purple);
+}

--- a/css-custom-functions/responsive-narrow-wide/index.html
+++ b/css-custom-functions/responsive-narrow-wide/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Responsive narrow-wide function</title>
+    <link href="style.css" rel="stylesheet" />
+  </head>
+  <body>
+    <section>
+      <h2>Responsive narrow-wide function</h2>
+      <p>
+        This example features a custom CSS function called
+        <code>--narrow-wide()</code>, which takes two parameters — a value to
+        apply to a narrow layout and a value to apply to a wide layout.
+      </p>
+    </section>
+    <section>
+      <h2>Usage</h2>
+      <p>
+        The custom function is very useful — you can use it as the value of just
+        about any property where you want to provide a choice of values — one
+        for a narrow layout and one for a wide layout.
+      </p>
+    </section>
+    <section>
+      <h2>Defining the function</h2>
+      <p>
+        The <code>--narrow-wide()</code> function is built using two CSS custom
+        properties and a media query to detect whether the viewport is narrower
+        or wider than the provided breakpoint, and return one value or the other
+        as appropriate.
+      </p>
+    </section>
+  </body>
+</html>

--- a/css-custom-functions/responsive-narrow-wide/index.html
+++ b/css-custom-functions/responsive-narrow-wide/index.html
@@ -6,6 +6,12 @@
     <link href="style.css" rel="stylesheet" />
   </head>
   <body>
+    <p class="support">
+      ⚠️ Your browser doesn't currently support
+      <a href="https://drafts.csswg.org/css-mixins-1/#defining-custom-functions"
+        >CSS custom functions</a
+      >.
+    </p>
     <section>
       <h2>Responsive narrow-wide function</h2>
       <p>

--- a/css-custom-functions/responsive-narrow-wide/style.css
+++ b/css-custom-functions/responsive-narrow-wide/style.css
@@ -1,0 +1,29 @@
+@function --narrow-wide(--narrow, --wide) {
+  result: var(--wide);
+  @media (width < 700px) {
+    result: var(--narrow);
+  }
+}
+
+/*
+This could also be written using a CSS if() function, like so:
+@function --narrow-wide(--narrow, --wide) {
+  result: if(media(width < 700px): var(--narrow) ; else: var(--wide));
+}
+*/
+
+body {
+  display: grid;
+  grid-template-columns: repeat(--narrow-wide(1, 3), 1fr);
+  gap: --narrow-wide(0, 20px);
+  padding: 0 20px;
+}
+
+h2 {
+  font-size: --narrow-wide(2.5rem, 2rem);
+}
+
+p {
+  font-size: --narrow-wide(1.4rem, 1rem);
+  line-height: 1.5;
+}

--- a/css-custom-functions/responsive-narrow-wide/style.css
+++ b/css-custom-functions/responsive-narrow-wide/style.css
@@ -12,6 +12,16 @@ This could also be written using a CSS if() function, like so:
 }
 */
 
+/* Function that returns a value of none to hide a "not supported" banner
+if CSS custom functions are supported. If not, the banner will show. */
+@function --supports() {
+  result: none;
+}
+
+html {
+  font-family: system-ui;
+}
+
 body {
   display: grid;
   grid-template-columns: repeat(--narrow-wide(1, 3), 1fr);
@@ -26,4 +36,16 @@ h2 {
 p {
   font-size: --narrow-wide(1.4rem, 1rem);
   line-height: 1.5;
+}
+
+/* Styling for the support banner */
+.support {
+  border-radius: 0;
+  border: 6px dashed black;
+  background-color: #fef0c3;
+  font-size: 1.3rem;
+  padding: 1rem;
+  position: absolute;
+  inset: 25%;
+  display: --supports();
 }


### PR DESCRIPTION
I'm about to start documenting [CSS custom functions](https://drafts.csswg.org/css-mixins-1/#defining-custom-functions), which has [landed in Chrome 139](https://chromestatus.com/feature/5179721933651968).

This PR adds some associated demos to the `dom-examples` repo.