### PR TITLE
fix snafu in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "contact-picker" directory contains an example showing usage of the [Contact Picker API](https://developer.mozilla.org/en-US/docs/Web/API/Contact_Picker_API). [See the example live](https://mdn.github.io/dom-examples/contact-picker/).
 
-- The "css-carousels" directory contains two examples showing how to use the CSS Carousel features — [a set of color adjustment functions](https://mdn.github.io/dom-examples/css-carousels/color-adjust-functions/), a [complex gradient background function](https://mdn.github.io/dom-examples/css-carousels/gradient-function/), and a [responsive narrow/wide value selection function](https://mdn.github.io/dom-examples/css-carousels/responsive-narrow-wide/).
+- The "css-carousels" directory contains two examples showing how to use the CSS Carousel features — [a basic example featuring scroll buttons and scroll markers](https://mdn.github.io/dom-examples/css-carousels/scroll-button-scroll-marker/), and an [example that also uses the `::columns` pseudo-class to paginate the content](https://mdn.github.io/dom-examples/css-carousels/scroll-button-scroll-marker-with-columns/).
 
-- The "css-custom-functions" directory contains three examples showing how to use CSS custom functions — [a basic example featuring scroll buttons and scroll markers](https://mdn.github.io/dom-examples/css-carousels/scroll-button-scroll-marker/), and an [example that also uses the `::columns` pseudo-class to paginate the content](https://mdn.github.io/dom-examples/css-carousels/scroll-button-scroll-marker-with-columns/).
+- The "css-custom-functions" directory contains three examples showing how to use CSS custom functions — [a set of color adjustment functions](https://mdn.github.io/dom-examples/css-custom-functions/color-adjust-functions/), a [complex gradient background function](https://mdn.github.io/dom-examples/css-custom-functions/gradient-function/), and a [responsive narrow/wide value selection function](https://mdn.github.io/dom-examples/css-custom-functions/responsive-narrow-wide/).
 
 - The "css-painting" directory contains examples demonstrating the [CSS Painting API](https://developer.mozilla.org/docs/Web/API/CSS_Painting_API). See the [examples live](https://mdn.github.io/dom-examples/css-painting).
 


### PR DESCRIPTION
When I added the CSS custom functions examples, I made a mess of the live example links in the README. This PR fixes that ;-)