### PR TITLE
Improve compat notes and behavior on popover-hint demo

### DIFF
--- a/popover-api/popover-hint/index.css
+++ b/popover-api/popover-hint/index.css
@@ -5,7 +5,7 @@
 }
 
 html {
-  font-family: sans-serif;
+  font-family: system-ui;
   height: 100%;
   overflow: hidden;
 }
@@ -14,20 +14,21 @@ body {
   height: inherit;
   background: #ccc;
   margin: 0;
-}
-
-#wrapper {
-  height: inherit;
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+#wrapper {
+  position: relative;
+  width: 60%;
+  max-width: 500px;
 }
 
 /* Button bar styling */
 
 #button-bar {
   height: 48px;
-  width: 30%;
   min-width: 300px;
   padding: 8px;
   border-radius: 6px;
@@ -36,6 +37,7 @@ body {
   display: flex;
   justify-content: space-around;
   gap: 10px;
+  z-index: 1;
 }
 
 /* Button styling */
@@ -61,6 +63,7 @@ body {
 [popover="auto"] {
   inset: unset;
   position: absolute;
+  bottom: 0;
   bottom: calc(anchor(top) + 20px);
   justify-self: anchor-center;
   margin: 0;
@@ -126,11 +129,24 @@ body {
   margin: 0;
   padding: 16px;
   box-shadow: 1px 1px 3px #999;
+  z-index: -1;
+}
+
+.help-para p {
+  margin: 0;
+}
+
+.help-para p:first-child {
+  margin-bottom: 1rem;
 }
 
 @media (max-width: 640px) {
   .help-para {
     width: auto;
     right: 16px;
+  }
+
+  #wrapper {
+    width: 90%;
   }
 }

--- a/popover-api/popover-hint/index.css
+++ b/popover-api/popover-hint/index.css
@@ -20,7 +20,6 @@ body {
 }
 
 #wrapper {
-  position: relative;
   width: 60%;
   max-width: 500px;
 }
@@ -37,7 +36,8 @@ body {
   display: flex;
   justify-content: space-around;
   gap: 10px;
-  z-index: 1;
+  z-index: 2;
+  position: relative;
 }
 
 /* Button styling */
@@ -129,7 +129,7 @@ body {
   margin: 0;
   padding: 16px;
   box-shadow: 1px 1px 3px #999;
-  z-index: -1;
+  z-index: 1;
 }
 
 .help-para p {

--- a/popover-api/popover-hint/index.css
+++ b/popover-api/popover-hint/index.css
@@ -63,7 +63,6 @@ body {
 [popover="auto"] {
   inset: unset;
   position: absolute;
-  bottom: 0;
   bottom: calc(anchor(top) + 20px);
   justify-self: anchor-center;
   margin: 0;

--- a/popover-api/popover-hint/index.html
+++ b/popover-api/popover-hint/index.html
@@ -17,6 +17,8 @@
           Menu A
         </button>
 
+        <div id="tooltip-1" class="tooltip" popover="hint">Tooltip A</div>
+
         <button
           popovertarget="submenu-2"
           popovertargetaction="toggle"
@@ -24,26 +26,27 @@
           Menu B
         </button>
 
+        <div id="tooltip-2" class="tooltip" popover="hint">Tooltip B</div>
+
         <button
           popovertarget="submenu-3"
           popovertargetaction="toggle"
           id="menu-3">
           Menu C
         </button>
-      </section>
-      <div id="submenu-1" popover="auto">
-        <button>Option A</button><br /><button>Option B</button>
-      </div>
-      <div id="submenu-2" popover="auto">
-        <button>Option A</button><br /><button>Option B</button>
-      </div>
-      <div id="submenu-3" popover="auto">
-        <button>Option A</button><br /><button>Option B</button>
-      </div>
 
-      <div id="tooltip-1" class="tooltip" popover="hint">Tooltip A</div>
-      <div id="tooltip-2" class="tooltip" popover="hint">Tooltip B</div>
-      <div id="tooltip-3" class="tooltip" popover="hint">Tooltip C</div>
+        <div id="tooltip-3" class="tooltip" popover="hint">Tooltip C</div>
+
+        <div id="submenu-1" popover="auto">
+          <button>Option A</button><br /><button>Option B</button>
+        </div>
+        <div id="submenu-2" popover="auto">
+          <button>Option A</button><br /><button>Option B</button>
+        </div>
+        <div id="submenu-3" popover="auto">
+          <button>Option A</button><br /><button>Option B</button>
+        </div>
+      </section>
     </div>
 
     <div class="help-para">

--- a/popover-api/popover-hint/index.html
+++ b/popover-api/popover-hint/index.html
@@ -15,27 +15,24 @@
           popovertargetaction="toggle"
           id="menu-1">
           Menu A
+          <div id="tooltip-1" class="tooltip" popover="hint">Tooltip A</div>
         </button>
-
-        <div id="tooltip-1" class="tooltip" popover="hint">Tooltip A</div>
 
         <button
           popovertarget="submenu-2"
           popovertargetaction="toggle"
           id="menu-2">
           Menu B
+          <div id="tooltip-2" class="tooltip" popover="hint">Tooltip B</div>
         </button>
-
-        <div id="tooltip-2" class="tooltip" popover="hint">Tooltip B</div>
 
         <button
           popovertarget="submenu-3"
           popovertargetaction="toggle"
           id="menu-3">
           Menu C
+          <div id="tooltip-3" class="tooltip" popover="hint">Tooltip C</div>
         </button>
-
-        <div id="tooltip-3" class="tooltip" popover="hint">Tooltip C</div>
 
         <div id="submenu-1" popover="auto">
           <button>Option A</button><br /><button>Option B</button>

--- a/popover-api/popover-hint/index.html
+++ b/popover-api/popover-hint/index.html
@@ -31,32 +31,48 @@
           Menu C
         </button>
       </section>
+      <div id="submenu-1" popover="auto">
+        <button>Option A</button><br /><button>Option B</button>
+      </div>
+      <div id="submenu-2" popover="auto">
+        <button>Option A</button><br /><button>Option B</button>
+      </div>
+      <div id="submenu-3" popover="auto">
+        <button>Option A</button><br /><button>Option B</button>
+      </div>
+
+      <div id="tooltip-1" class="tooltip" popover="hint">Tooltip A</div>
+      <div id="tooltip-2" class="tooltip" popover="hint">Tooltip B</div>
+      <div id="tooltip-3" class="tooltip" popover="hint">Tooltip C</div>
     </div>
 
-    <p class="help-para">
-      Press the buttons to show the auto popovers. Hover or focus the buttons to
-      show the hint popovers. When an auto popover is shown, you can show the
-      hint popovers without hiding it. See
-      <a
-        href="https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using#using_hint_popover_state"
-        >Using "hint" popover state</a
-      >
-      for more information. Note that in non-supporting browsers, the position
-      of the popovers is broken.
-    </p>
-
-    <div id="submenu-1" popover="auto">
-      <button>Option A</button><br /><button>Option B</button>
+    <div class="help-para">
+      <p>
+        Press the buttons to show the auto popovers. Hover or focus the buttons
+        to show the hint popovers. When an auto popover is shown, you can show
+        the hint popovers without hiding it. See
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using#using_hint_popover_state"
+          >Using "hint" popover state</a
+        >
+        for more information.
+      </p>
+      <p>
+        Note that this demo uses both hint popovers and CSS anchor positioning.
+        Browsers that don't support the former will experience different tooltip
+        behavior. Browsers that don't support the latter will not see the menus
+        and tooltips appear in the correct position relative to each button on
+        the button bar. Check browser support for
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover#browser_compatibility"
+          >hint popovers</a
+        >
+        and
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/CSS/position-anchor#browser_compatibility"
+          >anchor-positioning</a
+        >.
+      </p>
     </div>
-    <div id="submenu-2" popover="auto">
-      <button>Option A</button><br /><button>Option B</button>
-    </div>
-    <div id="submenu-3" popover="auto">
-      <button>Option A</button><br /><button>Option B</button>
-    </div>
-
-    <div id="tooltip-1" class="tooltip" popover="hint">Tooltip A</div>
-    <div id="tooltip-2" class="tooltip" popover="hint">Tooltip B</div>
-    <div id="tooltip-3" class="tooltip" popover="hint">Tooltip C</div>
   </body>
 </html>


### PR DESCRIPTION
As discussed in https://github.com/mdn/content/issues/40881, the browser support situation in our `popover="hint"` demo is not very clear. In browsers that don't support `popover="hint"`, the tooltip behavior is not quite right. And in browsers that don't support CSS anchor positioning, the demo looks broken because the popovers don't appear as expected.

To mitigate these issues, I have updated the demo. Specifically, I have:

- Added more details to the help paragraph about the support situation.
- Moved the popovers inside the `#wrapper` `<div>` and given it a `position` of `relative` so that they should be positioned relative to the `<div>` rather than the `<body>` in non-supporting browsers (note: this still doesan't quite work property. Setting a fallback inset property still seems to position them relative to the `<body>`, and I'm not sure why)
- Updated some of the other code relating to the button bar position to make the above possible.

I'm still not 100% happy with this, but the available information is a lot more useful now, and the demo looks less broken in non-supporitng browsers.

Once we've got this update merged, I'll then look at the associated MDN content and see if any of it needs updating as a result.