### PR TITLE
Fix: use shorthand syntax for `salt` in HKDF example

### DIFF
--- a/web-crypto/derive-key/hkdf.js
+++ b/web-crypto/derive-key/hkdf.js
@@ -23,19 +23,19 @@
   derive an AES-GCM key using HKDF.
   */
   function getKey(keyMaterial, salt) {
-    return window.crypto.subtle.deriveKey(
-      {
-        name: "HKDF",
-        salt: salt,
-        info: new Uint8Array("Encryption example"),
-        hash: "SHA-256",
-      },
-      keyMaterial,
-      { name: "AES-GCM", length: 256 },
-      true,
-      ["encrypt", "decrypt"]
-    );
-  }
+  return window.crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      salt,   // ✅ shorthand
+      info: new Uint8Array("Encryption example"),
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"]
+  );
+}
 
   /*
     Encrypt the message using the secret key.


### PR DESCRIPTION
This PR simplifies the `getKey` function in the HKDF example by using object property shorthand for `salt`.

**Before:**
salt: salt

**After:**
salt

This change improves readability and follows modern JavaScript best practices, while keeping the code functionally identical.
