### PR TITLE
Add notifications demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "navigation-api" directory contains a basic example that demonstrates some features of the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API). [Run the demo live](https://mdn.github.io/dom-examples/navigation-api/).
 
+- The "notifications" directory contains one example showing how to make and handle persistent notifications, and another showing how to make and handle non-persistent notifications, using the [Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API).
+
+  - [Run the persistent notifications demo](https://mdn.github.io/dom-examples/notifications/non-persistent/).
+  - [Run the non-persistent notifications demo](https://mdn.github.io/dom-examples/notifications/non-persistent/)
+
 - The "payment-request" directory contains examples of the [Payment Request API](https://developer.mozilla.org/docs/Web/API/Payment_Request_API).
 
 - The "pointerevents" directory is for examples and demos of the [Pointer Events](https://developer.mozilla.org/docs/Web/API/Pointer_events) standard.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Code examples that accompany various MDN DOM and Web API documentation pages.
 
 - The "notifications" directory contains one example showing how to make and handle persistent notifications, and another showing how to make and handle non-persistent notifications, using the [Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API).
 
-  - [Run the persistent notifications demo](https://mdn.github.io/dom-examples/notifications/non-persistent/).
+  - [Run the persistent notifications demo](https://mdn.github.io/dom-examples/notifications/persistent/).
   - [Run the non-persistent notifications demo](https://mdn.github.io/dom-examples/notifications/non-persistent/)
 
 - The "payment-request" directory contains examples of the [Payment Request API](https://developer.mozilla.org/docs/Web/API/Payment_Request_API).

--- a/notifications/non-persistent/index.html
+++ b/notifications/non-persistent/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Non-persistent notifications</title>
+    <script src="page.js" defer></script>
+  </head>
+
+  <body>
+    <button id="notify-me">Notify me!</button>
+
+    <p>
+      This website shows how to make and handle non-persistent notifications.
+    </p>
+
+    <p>When we click the "Notify me!" button, the website:</p>
+    <ol>
+      <li>
+        Checks whether the website has permission to show notifications, asking
+        for permission if necessary.
+      </li>
+      <li>If permission is granted, starts a one-second timer.</li>
+      <li>
+        When the timer expires, creates a non-persistent notification using the
+        <code>Notification()</code> constructor.
+      </li>
+      <li>
+        Adds event handlers to the main events dispatched on the
+        <code>Notification</code> interface.
+      </li>
+    </ol>
+
+    <p>
+      When the notification is shown, the user clicks it, or the user closes it,
+      the corresponding event handler runs and just logs the event.
+    </p>
+  </body>
+</html>

--- a/notifications/non-persistent/index.html
+++ b/notifications/non-persistent/index.html
@@ -14,7 +14,7 @@
       This website shows how to make and handle non-persistent notifications.
     </p>
 
-    <p>When we click the "Notify me!" button, the website:</p>
+    <p>When we click the "Notify me!" button, the website does the following:</p>
     <ol>
       <li>
         Checks whether the website has permission to show notifications, asking
@@ -33,7 +33,7 @@
 
     <p>
       When the notification is shown, the user clicks it, or the user closes it,
-      the corresponding event handler runs and just logs the event.
+      the corresponding event handler runs and logs the event.
     </p>
   </body>
 </html>

--- a/notifications/non-persistent/page.js
+++ b/notifications/non-persistent/page.js
@@ -1,0 +1,24 @@
+const notifyMe = document.querySelector("#notify-me");
+notifyMe.addEventListener("click", async () => {
+	const permission = await Notification.requestPermission();
+
+	if (permission === "granted") {
+		setTimeout(() => {
+			const notification = new Notification("Hello!");
+
+			notification.addEventListener("show", () => {
+				console.log("showing!");
+			});
+
+			notification.addEventListener("click", () => {
+				console.log("clicked!");
+			});
+
+			notification.addEventListener("close", () => {
+				console.log("closed!");
+			});
+		}, 1000);
+	} else {
+		console.log("Permission to show notifications was not granted");
+	}
+});

--- a/notifications/persistent/actions/donut.html
+++ b/notifications/persistent/actions/donut.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<title>example page</title>
-		<link rel="stylesheet" href="style.css" />
-	</head>
+  <head>
+    <meta charset="utf-8" />
+    <title>Donut</title>
+  </head>
 
-	<body>
-		<p>Enjoy your donut!</p>
-	</body>
+  <body>
+    <p>Enjoy your donut!</p>
+  </body>
 </html>

--- a/notifications/persistent/actions/donut.html
+++ b/notifications/persistent/actions/donut.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>example page</title>
+		<link rel="stylesheet" href="style.css" />
+	</head>
+
+	<body>
+		<p>Enjoy your donut!</p>
+	</body>
+</html>

--- a/notifications/persistent/actions/tea.html
+++ b/notifications/persistent/actions/tea.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>example page</title>
+		<link rel="stylesheet" href="style.css" />
+	</head>
+
+	<body>
+		<p>Enjoy your tea!</p>
+	</body>
+</html>

--- a/notifications/persistent/actions/tea.html
+++ b/notifications/persistent/actions/tea.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<title>example page</title>
-		<link rel="stylesheet" href="style.css" />
-	</head>
+  <head>
+    <meta charset="utf-8" />
+    <title>Tea</title>
+  </head>
 
-	<body>
-		<p>Enjoy your tea!</p>
-	</body>
+  <body>
+    <p>Enjoy your tea!</p>
+  </body>
 </html>

--- a/notifications/persistent/index.html
+++ b/notifications/persistent/index.html
@@ -14,7 +14,7 @@
 
     <p>
       It registers a service worker, whose job is to handle notifications. When
-      we click the "Notify me!" button, the website:
+      the "Notify me!" button is clicked, the website does the following:
     </p>
     <ol>
       <li>
@@ -43,7 +43,7 @@
     <p>
       The service worker's <code>notificationclick</code> handler checks the
       value of the event's <code>action</code>, and responds by opening the
-      appropriate page in the website.
+      appropriate web page.
     </p>
   </body>
 </html>

--- a/notifications/persistent/index.html
+++ b/notifications/persistent/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Persistent notifications</title>
+    <script src="page.js" defer></script>
+  </head>
+
+  <body>
+    <button id="notify-me">Notify me!</button>
+
+    <p>This website shows how to make and handle persistent notifications.</p>
+
+    <p>
+      It registers a service worker, whose job is to handle notifications. When
+      we click the "Notify me!" button, the website:
+    </p>
+    <ol>
+      <li>
+        Checks whether the website has permission to show notifications, asking
+        for permission if necessary.
+      </li>
+      <li>If permission is granted, starts a one-second timer.</li>
+      <li>
+        When the timer expires, gets the service worker registration, waiting
+        for it to become active if necessary.
+      </li>
+      <li>
+        Calls <code>registration.showNotification()</code>, passing in two
+        actions.
+      </li>
+    </ol>
+
+    <p>
+      The notification presents the actions to the user. If the user clicks the
+      notification, then the browser starts the service worker, if it is not
+      already running, and dispatches the
+      <code>notificationclick</code> event. If the user selected an action, then
+      the event object includes the selected action.
+    </p>
+
+    <p>
+      The service worker's <code>notificationclick</code> handler checks the
+      value of the event's <code>action</code>, and responds by opening the
+      appropriate page in the website.
+    </p>
+  </body>
+</html>

--- a/notifications/persistent/page.js
+++ b/notifications/persistent/page.js
@@ -1,0 +1,20 @@
+navigator.serviceWorker.register("sw.js");
+
+const notifyMe = document.querySelector("#notify-me");
+notifyMe.addEventListener("click", async () => {
+  const permission = await Notification.requestPermission();
+
+  if (permission === "granted") {
+    setTimeout(async () => {
+      const registration = await navigator.serviceWorker.ready;
+      registration.showNotification("Hello!", {
+        actions: [
+          { action: "donut", title: "Eat a donut" },
+          { action: "tea", title: "Drink a cup of tea" },
+        ],
+      });
+    }, 1000);
+  } else {
+    console.log("Permission to show notifications was not granted");
+  }
+});

--- a/notifications/persistent/sw.js
+++ b/notifications/persistent/sw.js
@@ -1,0 +1,10 @@
+self.addEventListener("notificationclick", (event) => {
+  switch (event.action) {
+    case "donut":
+      clients.openWindow("actions/donut.html");
+      break;
+    case "tea":
+      clients.openWindow("actions/tea.html");
+      break;
+  }
+});


### PR DESCRIPTION
This adds a couple of demos of the Notifications API, one showing persistent notifications, and one showing non-persistent notifications.

I wonder if it might be better to have the persistent one creating the notification in the SW, as well as managing it. That might be a more common use case, but it makes things a little more complicated...

Part of the fix for https://github.com/mdn/content/issues/30931.