### PR TITLE
Fix: use object literal shorthand in derive Key example

### DIFF
--- a/web-crypto/derive-key/ecdh.js
+++ b/web-crypto/derive-key/ecdh.js
@@ -29,7 +29,7 @@
     ciphertext = await window.crypto.subtle.encrypt(
       {
         name: "AES-GCM",
-        iv: iv,
+        iv
       },
       secretKey,
       encoded
@@ -59,7 +59,7 @@
       let decrypted = await window.crypto.subtle.decrypt(
         {
           name: "AES-GCM",
-          iv: iv,
+          iv
         },
         secretKey,
         ciphertext

--- a/web-crypto/derive-key/hkdf.js
+++ b/web-crypto/derive-key/hkdf.js
@@ -26,7 +26,7 @@
     return window.crypto.subtle.deriveKey(
       {
         name: "HKDF",
-        salt: salt,
+        salt,
         info: new Uint8Array("Encryption example"),
         hash: "SHA-256",
       },

--- a/web-crypto/derive-key/pbkdf2.js
+++ b/web-crypto/derive-key/pbkdf2.js
@@ -70,7 +70,7 @@
     ciphertext = await window.crypto.subtle.encrypt(
       {
         name: "AES-GCM",
-        iv: iv
+        iv
       },
       key,
       encoded
@@ -104,7 +104,7 @@
       let decrypted = await window.crypto.subtle.decrypt(
         {
           name: "AES-GCM",
-          iv: iv
+          iv
         },
         key,
         ciphertext

--- a/web-crypto/encrypt-decrypt/aes-gcm.js
+++ b/web-crypto/encrypt-decrypt/aes-gcm.js
@@ -28,7 +28,7 @@
     ciphertext = await window.crypto.subtle.encrypt(
       {
         name: "AES-GCM",
-        iv: iv
+        iv
       },
       key,
       encoded
@@ -51,7 +51,7 @@
     let decrypted = await window.crypto.subtle.decrypt(
       {
         name: "AES-GCM",
-        iv: iv
+        iv
       },
       key,
       ciphertext

--- a/web-crypto/import-key/raw.js
+++ b/web-crypto/import-key/raw.js
@@ -46,7 +46,7 @@
     const ciphertext = await window.crypto.subtle.encrypt(
       {
         name: "AES-GCM",
-        iv: iv
+        iv
       },
       secretKey,
       encoded

--- a/web-crypto/unwrap-key/raw.js
+++ b/web-crypto/unwrap-key/raw.js
@@ -117,7 +117,7 @@
     const ciphertext = await window.crypto.subtle.encrypt(
       {
         name: "AES-GCM",
-        iv: iv
+        iv
       },
       secretKey,
       encoded

--- a/web-crypto/wrap-key/jwk.js
+++ b/web-crypto/wrap-key/jwk.js
@@ -54,7 +54,7 @@
       wrappingKey,
       {
         name: "AES-GCM",
-        iv: iv
+        iv
       }
     );
 

--- a/web-crypto/wrap-key/pkcs8.js
+++ b/web-crypto/wrap-key/pkcs8.js
@@ -54,7 +54,7 @@
       wrappingKey,
       {
         name: "AES-GCM",
-        iv: iv
+        iv
       }
     );
 

--- a/web-crypto/wrap-key/spki.js
+++ b/web-crypto/wrap-key/spki.js
@@ -54,7 +54,7 @@
       wrappingKey,
       {
         name: "AES-CBC",
-        iv: iv
+        iv
       }
     );
 


### PR DESCRIPTION
This PR updates the deriveKey example in the SubtleCrypto docs to use object literal shorthand.
The repo was already updated to use shorthand.
This keeps dom-examples consistent with the updated docs.

Fixes #309
