### PR TITLE
chore(CODEOWNERS): add Engineering for workflows and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,7 @@
 # For more information, see:
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-# Default
-* @mdn/core-yari-content
+* @mdn/content-team
 
 /.github/workflows/ @mdn/engineering
-/.github/CODEOWNERS @mdn/core-yari-content @mdn/engineering
+/.github/CODEOWNERS @mdn/content-team @mdn/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,6 @@
 
 # Default
 * @mdn/core-yari-content
+
+/.github/workflows/ @mdn/engineering
+/.github/CODEOWNERS @mdn/core-yari-content @mdn/engineering


### PR DESCRIPTION
### Description

Updates the CODEOWNERS file to ensure:
- `/.github/workflows/` is owned by `@mdn/engineering`
- `/.github/CODEOWNERS` is owned by the default code owner and `@mdn/engineering`

### Motivation

Ensures the engineering team has oversight of workflow changes, and CODEOWNERS file modifications across repositories.

### Additional details

See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/888.