### PR TITLE
ci(workflows): assign explicit permissions

### DIFF
--- a/.github/workflows/pr-merge-conflicts.yml
+++ b/.github/workflows/pr-merge-conflicts.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: [synchronize]
 
+permissions:
+  # Label pull requests.
+  pull-requests: write
+
 jobs:
   label-merge-conflicts:
     uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main


### PR DESCRIPTION
### Description

Adds explicit `permissions:` configuration to workflow files that don't already have permissions defined either at the workflow level or for all jobs.

- If the workflow doesn't use `secrets.GITHUB_TOKEN` or `github.token`, sets `permissions: {}` to restrict all permissions.
- If the workflow uses the GitHub token, adds `permissions:` with required permissions.

### Motivation

Security best practice to explicitly declare `GITHUB_TOKEN` permissions instead of relying on default permissions, following the principle of least privilege by ensuring workflows only have the permissions they actually need.

### Additional details

See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/924.
