### PR TITLE
Add links to all Web Crypto API examples - Fixes #40

### DIFF
--- a/web-crypto/README.md
+++ b/web-crypto/README.md
@@ -2,6 +2,18 @@
 
 Examples of how to use the [Web Crypto API](https://developer.mozilla.org/docs/Web/API/Web_Crypto_API).
 
-* [sign/verify](sign-verify/index.html): examples showing how to use the [`SubtleCrypto.sign()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign) and [`SubtleCrypto.verify()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify) APIs.
+* [derive-bits](derive-bits/index.html): examples showing how to use the [`SubtleCrypto.deriveBits()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits) API.
+
+* [derive-key](derive-key/index.html): examples showing how to use the [`SubtleCrypto.deriveKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey) API.
 
 * [encrypt/decrypt](encrypt-decrypt/index.html): examples showing how to use the [`SubtleCrypto.encrypt()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/encrypt) and [`SubtleCrypto.decrypt()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/decrypt) APIs.
+
+* [export-key](export-key/index.html): examples showing how to use the [`SubtleCrypto.exportKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey) API.
+
+* [import-key](import-key/index.html): examples showing how to use the [`SubtleCrypto.importKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey) API.
+
+* [sign/verify](sign-verify/index.html): examples showing how to use the [`SubtleCrypto.sign()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign) and [`SubtleCrypto.verify()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify) APIs.
+
+* [unwrap-key](unwrap-key/index.html): examples showing how to use the [`SubtleCrypto.unwrapKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/unwrapKey) API.
+
+* [wrap-key](wrap-key/index.html): examples showing how to use the [`SubtleCrypto.wrapKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey) API.


### PR DESCRIPTION
## Summary

Adds MDN documentation links for all 8 Web Crypto API examples, completing the 6-year-old request in issue #40.

## Changes

Updated `web-crypto/README.md` to include links to all examples:

✅ **Added links for 6 missing examples:**
- `derive-bits` → [`SubtleCrypto.deriveBits()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits)
- `derive-key` → [`SubtleCrypto.deriveKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey)
- `export-key` → [`SubtleCrypto.exportKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey)
- `import-key` → [`SubtleCrypto.importKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey)
- `unwrap-key` → [`SubtleCrypto.unwrapKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/unwrapKey)
- `wrap-key` → [`SubtleCrypto.wrapKey()`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey)

✅ **Kept existing links:**
- `encrypt-decrypt`
- `sign-verify`

## Before

Only 2 examples were listed:
```markdown
* [sign/verify](sign-verify/index.html)
* [encrypt/decrypt](encrypt-decrypt/index.html)
```

## After

All 8 examples are now listed with MDN links:
```markdown
* [derive-bits](derive-bits/index.html)
* [derive-key](derive-key/index.html)
* [encrypt/decrypt](encrypt-decrypt/index.html)
* [export-key](export-key/index.html)
* [import-key](import-key/index.html)
* [sign/verify](sign-verify/index.html)
* [unwrap-key](unwrap-key/index.html)
* [wrap-key](wrap-key/index.html)
```

## Benefits

1. **Complete Documentation**: All examples now have links
2. **Better Discoverability**: Users can find all 8 examples
3. **Direct API Reference**: Each example links to its MDN API page
4. **Consistent Format**: Follows the existing pattern

## Checklist from #40

- [x] Add link to derive-bits example
- [x] Add link to derive-key example
- [x] Add links to encrypt-decrypt example (already existed)
- [x] Add link to export-key example
- [x] Add link to import-key example
- [x] Add links to sign-verify example (already existed)
- [x] Add links to unwrap-key example
- [x] Add link to wrap-key example

Fixes #40