### PR TITLE
Initialize year selection to current year

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Do not specify supported browsers and their versions in code comments or prose, 
 - The "edit-context" directory contains examples demonstrating the [EditContext API](https://developer.mozilla.org/docs/Web/API/EditContext_API). See the [list of examples](https://github.com/mdn/dom-examples/tree/main/edit-context/).
 
 - The "file-system-api" directory contains multiple examples demonstrating usage of the [File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API):
-
   - [createSyncAccessHandle() mode test](https://mdn.github.io/dom-examples/file-system-api/createsyncaccesshandle-mode/): Demonstrates usage of [FileSystemFileHandle.createSyncAccessHandle()](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createSyncAccessHandle)
   - [createWritable() mode test](https://mdn.github.io/dom-examples/file-system-api/createwritable-mode/): Demonstrates usage of [FileSystemFileHandle.createWritable()](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createWritable)
   - [FileSystemHandle.remove() demo](https://mdn.github.io/dom-examples/file-system-api/filesystemhandle-remove/): Demonstrates usage of [FileSystemHandle.remove()](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/remove)
@@ -78,7 +77,6 @@ Do not specify supported browsers and their versions in code comments or prose, 
 - The "navigation-api" directory contains a basic example that demonstrates some features of the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API). [Run the demo live](https://mdn.github.io/dom-examples/navigation-api/).
 
 - The "notifications" directory contains one example showing how to make and handle persistent notifications, and another showing how to make and handle non-persistent notifications, using the [Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API).
-
   - [Run the persistent notifications demo](https://mdn.github.io/dom-examples/notifications/persistent/).
   - [Run the non-persistent notifications demo](https://mdn.github.io/dom-examples/notifications/non-persistent/)
 
@@ -110,6 +108,8 @@ Do not specify supported browsers and their versions in code comments or prose, 
 
 - The "touchevents" directory is for examples and demos of the [Touch Events](https://developer.mozilla.org/docs/Web/API/Touch_events) standard.
 
+- The "to-do-notifications" directory contains a to-do list notifications app demonstrating [IndexedDB API](https://developer.mozilla.org/docs/Web/API/IndexedDB_API) for data storage and [Notifications API](https://developer.mozilla.org/docs/Web/API/Notifications_API) for deadline alerts. See [Checking when a deadline is due](https://developer.mozilla.org/docs/Web/API/IndexedDB_API/Checking_when_a_deadline_is_due) for a detailed walkthrough.
+
 - The "viewport-segments-api" directory contains an example demonstrating how to use the [Viewport Segments API](https://developer.mozilla.org/docs/Web/API/Viewport_Segments_API). [Run the example live](https://mdn.github.io/dom-examples/viewport-segments-api/).
 
 - The "view-transitions" directory contains examples and demos of the [View Transition API](https://developer.mozilla.org/docs/Web/API/View_Transition_API) standard. Go to the [View transition API demo index](https://mdn.github.io/dom-examples/view-transitions/) to see what's available.
@@ -121,7 +121,6 @@ Do not specify supported browsers and their versions in code comments or prose, 
 - The "web-storage" directory contains a basic demo to show usage of the Web Storage API. For more detail on how it works, read [Using the Web Storage API](https://developer.mozilla.org/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API). [View the demo live](https://mdn.github.io/dom-examples/web-storage/).
 
 - The "view-transitions" directory contains demos to show usage of the [View Transitions API](https://developer.mozilla.org/docs/Web/API/View_Transitions_API):
-
   - View transitions in a [single-page app](https://mdn.github.io/dom-examples/view-transitions/spa/)
   - View transitions in a [multiple-page app](https://mdn.github.io/dom-examples/view-transitions/mpa/)
   - Another example of view transitions in a [simple multiple-page app](https://mdn.github.io/dom-examples/view-transitions/mpa-homepage/)

--- a/to-do-notifications/README.md
+++ b/to-do-notifications/README.md
@@ -1,10 +1,7 @@
-to-do-notifications
-===================
+# to-do-notifications
 
-This is an Enhanced version of my basic to-do app, which stores to-do items via IndexedDB, and then also aims to provide notifications when to-do item deadlines are up, via the Notification and Vibration APIs.
+This is a to-do list notifications application that stores to-do items via [IndexedDB](https://developer.mozilla.org/docs/Web/API/IndexedDB_API) and provides notifications when to-do item deadlines are up via the [Notifications](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API) and [Vibration](https://developer.mozilla.org/docs/Web/API/Vibration_API) APIs.
 
-The IndexedDB and Notification API functionality all works on Firefox desktop, Firefox Android, Firefox OS, Chrome, and IE 10+.
+[View the demo live](https://mdn.github.io/dom-examples/to-do-notifications/).
 
-The Vibration API stuff works on Firefox OS and Firefox for Android.
-
-You can [try it out live](https://mdn.github.io/dom-examples/to-do-notifications/).
+See [Checking when a deadline is due](https://developer.mozilla.org/docs/Web/API/IndexedDB_API/Checking_when_a_deadline_is_due) for a detailed walkthrough explaining how this app works.

--- a/to-do-notifications/index.html
+++ b/to-do-notifications/index.html
@@ -87,21 +87,7 @@
       </div>
 
       <div class="third-width"><label for="deadline-year">Year:</label>
-        <select id="deadline-year" required>
-          <option value="2018">2018</option>
-          <option value="2019">2019</option>
-          <option value="2020">2020</option>
-          <option value="2021">2021</option>
-          <option value="2022">2022</option>
-          <option value="2023">2023</option>
-          <option value="2024">2024</option>
-          <option value="2025">2025</option>
-          <option value="2026">2026</option>
-          <option value="2027">2027</option>
-          <option value="2028">2028</option>
-          <option value="2029">2029</option>
-          <option value="2030">2030</option>
-        </select>
+        <select id="deadline-year" required></select>
       </div>
 
       <div><input type="submit" id="submit" value="Add Task"></div>

--- a/to-do-notifications/index.html
+++ b/to-do-notifications/index.html
@@ -1,35 +1,39 @@
 <!DOCTYPE HTML>
 <html lang="en-US">
+
 <head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=380">
-    <script src="scripts/todo.js"></script>
-	<title>To-do list with Notifications</title>
-	<!-- Icon originated from design by Sabine Wollender: http://thenounproject.com/wosamo/ -->
-	<link rel="icon" type="image/png" href="img/icon-128.png">
-    <link href='https://fonts.googleapis.com/css?family=Donegal+One|Lily+Script+One' rel='stylesheet' type='text/css'>
-	<link href="style/style.css" type="text/css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=380">
+  <script src="scripts/todo.js"></script>
+  <title>To-do list with Notifications</title>
+  <!-- Icon originated from design by Sabine Wollender: http://thenounproject.com/wosamo/ -->
+  <link rel="icon" type="image/png" href="img/icon-128.png">
+  <link href='https://fonts.googleapis.com/css?family=Donegal+One|Lily+Script+One' rel='stylesheet' type='text/css'>
+  <link href="style/style.css" type="text/css" rel="stylesheet">
 </head>
+
 <body>
 
-<h1>To-do list</h1>
+  <h1>To-do list</h1>
 
-<div class="task-box">
+  <div class="task-box">
 
-<ul id="task-list">
+    <ul id="task-list">
 
-</ul>
+    </ul>
 
-</div>
+  </div>
 
-<div class="form-box">
-<h2>Add new to-do item.</h2>
+  <div class="form-box">
+    <h2>Add new to-do item.</h2>
 
-<form id="task-form" action="index.html">
-  <div class="full-width"><label for="title">Task title:</label><input type="text" id="title" required></div>
-  <div class="half-width"><label for="deadline-hours">Hours (hh):</label><input type="number" id="deadline-hours" required></div>
-  <div class="half-width"><label for="deadline-minutes">Mins (mm):</label><input type="number" id="deadline-minutes" required></div>
-  <div class="third-width"><label for="deadline-day">Day:</label>
+    <form id="task-form" action="index.html">
+      <div class="full-width"><label for="title">Task title:</label><input type="text" id="title" required></div>
+      <div class="half-width"><label for="deadline-hours">Hours (hh):</label><input type="number" id="deadline-hours"
+          required></div>
+      <div class="half-width"><label for="deadline-minutes">Mins (mm):</label><input type="number" id="deadline-minutes"
+          required></div>
+      <div class="third-width"><label for="deadline-day">Day:</label>
         <select id="deadline-day" required>
           <option value="01">01</option>
           <option value="02">02</option>
@@ -62,55 +66,59 @@
           <option value="29">29</option>
           <option value="30">30</option>
           <option value="31">31</option>
-        </select></div>
+        </select>
+      </div>
 
-  <div class="third-width"><label for="deadline-month">Month:</label>
-       <select id="deadline-month" required>
-         <option value="January">January</option>
-         <option value="February">February</option>
-         <option value="March">March</option>
-         <option value="April">April</option>
-         <option value="May">May</option>
-         <option value="June">June</option>
-         <option value="July">July</option>
-         <option value="August">August</option>
-         <option value="September">September</option>
-         <option value="October">October</option>
-         <option value="November">November</option>
-         <option value="December">December</option>
-       </select></div>
+      <div class="third-width"><label for="deadline-month">Month:</label>
+        <select id="deadline-month" required>
+          <option value="January">January</option>
+          <option value="February">February</option>
+          <option value="March">March</option>
+          <option value="April">April</option>
+          <option value="May">May</option>
+          <option value="June">June</option>
+          <option value="July">July</option>
+          <option value="August">August</option>
+          <option value="September">September</option>
+          <option value="October">October</option>
+          <option value="November">November</option>
+          <option value="December">December</option>
+        </select>
+      </div>
 
-  <div class="third-width"><label for="deadline-year">Year:</label>
-       <select id="deadline-year" required>
-         <option value="2030">2030</option>
-         <option value="2029">2029</option>
-         <option value="2028">2028</option>
-         <option value="2027">2027</option>
-	       <option value="2026">2026</option>
-         <option value="2025">2025</option>
-         <option value="2024">2024</option>
-         <option value="2023">2023</option>
-         <option value="2022">2022</option>
-         <option value="2021">2021</option>
-         <option value="2020">2020</option>
-         <option value="2019">2019</option>
-         <option value="2018">2018</option>
-       </select></div>
+      <div class="third-width"><label for="deadline-year">Year:</label>
+        <select id="deadline-year" required>
+          <option value="2018">2018</option>
+          <option value="2019">2019</option>
+          <option value="2020">2020</option>
+          <option value="2021">2021</option>
+          <option value="2022">2022</option>
+          <option value="2023">2023</option>
+          <option value="2024">2024</option>
+          <option value="2025">2025</option>
+          <option value="2026">2026</option>
+          <option value="2027">2027</option>
+          <option value="2028">2028</option>
+          <option value="2029">2029</option>
+          <option value="2030">2030</option>
+        </select>
+      </div>
 
-  <div><input type="submit" id="submit" value="Add Task"></div>
-  <div></div>
-</form>
-</div>
+      <div><input type="submit" id="submit" value="Add Task"></div>
+      <div></div>
+    </form>
+  </div>
 
-<div id="toolbar">
-  <ul id="notifications">
+  <div id="toolbar">
+    <ul id="notifications">
 
-  </ul>
+    </ul>
 
-  <button id="enable">
-    Enable notifications
-  </button>
-</div>
+    <button id="enable">
+      Enable notifications
+    </button>
+  </div>
 
 </body>
+
 </html>

--- a/to-do-notifications/scripts/todo.js
+++ b/to-do-notifications/scripts/todo.js
@@ -42,9 +42,22 @@ window.onload = () => {
     notificationBtn.style.display = "none";
   }
 
-  // Set year to current year on initial load
-  year.value = new Date().getFullYear();
-  note.appendChild(createListItem("App initialised."));
+  // Populate year options starting from the current year
+  // and 12 years into the future
+  const currentYear = new Date().getFullYear();
+  for (let i = 0; i <= 12; i++) {
+    const option = document.createElement("option");
+    const yearValue = currentYear + i;
+    option.value = yearValue;
+    option.textContent = yearValue;
+    year.appendChild(option);
+  }
+
+  // Set the year field to the current year on initial load
+  year.value = currentYear;
+
+  // Log app initialization status
+  note.appendChild(createListItem("App initialized."));
 
   // Let us open our database
   const DBOpenRequest = window.indexedDB.open("toDoList", 4);
@@ -55,7 +68,7 @@ window.onload = () => {
   };
 
   DBOpenRequest.onsuccess = (event) => {
-    note.appendChild(createListItem("Database initialised."));
+    note.appendChild(createListItem("Database initialized."));
 
     // Store the result of opening the database in the db variable. This is used a lot below
     db = DBOpenRequest.result;
@@ -185,7 +198,9 @@ window.onload = () => {
     // Report on the success of the transaction completing, when everything is done
     transaction.oncomplete = () => {
       note.appendChild(
-        createListItem("Transaction completed: database modification finished.")
+        createListItem(
+          "Transaction completed: database modification finished.",
+        ),
       );
 
       // Update the display of data to show the newly added item, by running displayData() again.
@@ -196,8 +211,8 @@ window.onload = () => {
     transaction.onerror = () => {
       note.appendChild(
         createListItem(
-          `Transaction not opened due to error: ${transaction.error}`
-        )
+          `Transaction not opened due to error: ${transaction.error}`,
+        ),
       );
     };
 
@@ -213,7 +228,7 @@ window.onload = () => {
     const objectStoreRequest = objectStore.add(newItem[0]);
     objectStoreRequest.onsuccess = (event) => {
       // Report the success of our request
-      // (to detect whether it has been succesfully
+      // (to detect whether it has been successfully
       // added to the database, you'd look at transaction.oncomplete)
       note.appendChild(createListItem("Request successful."));
 
@@ -223,7 +238,7 @@ window.onload = () => {
       minutes.value = null;
       day.value = "01";
       month.value = "January";
-      year.value = new Date().getFullYear();
+      year.value = currentYear;
     };
   }
 

--- a/to-do-notifications/scripts/todo.js
+++ b/to-do-notifications/scripts/todo.js
@@ -1,43 +1,61 @@
 window.onload = () => {
-  const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+  const MONTHS = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
 
   // Hold an instance of a db object for us to store the IndexedDB data in
   let db;
 
   // Create a reference to the notifications list in the bottom of the app; we will write database messages into this list by
   // appending list items as children of this element
-  const note = document.getElementById('notifications');
+  const note = document.getElementById("notifications");
 
   // All other UI elements we need for the app
-  const taskList = document.getElementById('task-list');
-  const taskForm = document.getElementById('task-form');
-  const title = document.getElementById('title');
-  const hours = document.getElementById('deadline-hours');
-  const minutes = document.getElementById('deadline-minutes');
-  const day = document.getElementById('deadline-day');
-  const month = document.getElementById('deadline-month');
-  const year = document.getElementById('deadline-year');
-  const notificationBtn = document.getElementById('enable');
+  const taskList = document.getElementById("task-list");
+  const taskForm = document.getElementById("task-form");
+  const title = document.getElementById("title");
+  const hours = document.getElementById("deadline-hours");
+  const minutes = document.getElementById("deadline-minutes");
+  const day = document.getElementById("deadline-day");
+  const month = document.getElementById("deadline-month");
+  const year = document.getElementById("deadline-year");
+  const notificationBtn = document.getElementById("enable");
 
   // Do an initial check to see what the notification permission state is
-  if (Notification.permission === 'denied' || Notification.permission === 'default') {
-    notificationBtn.style.display = 'block';
+  if (
+    Notification.permission === "denied" ||
+    Notification.permission === "default"
+  ) {
+    notificationBtn.style.display = "block";
   } else {
-    notificationBtn.style.display = 'none';
+    notificationBtn.style.display = "none";
   }
 
-  note.appendChild(createListItem('App initialised.'));
+  // Set year to current year on initial load
+  year.value = new Date().getFullYear();
+  note.appendChild(createListItem("App initialised."));
 
   // Let us open our database
-  const DBOpenRequest = window.indexedDB.open('toDoList', 4);
+  const DBOpenRequest = window.indexedDB.open("toDoList", 4);
 
   // Register two event handlers to act on the database being opened successfully, or not
   DBOpenRequest.onerror = (event) => {
-    note.appendChild(createListItem('Error loading database.'));
+    note.appendChild(createListItem("Error loading database."));
   };
 
   DBOpenRequest.onsuccess = (event) => {
-    note.appendChild(createListItem('Database initialised.'));
+    note.appendChild(createListItem("Database initialised."));
 
     // Store the result of opening the database in the db variable. This is used a lot below
     db = DBOpenRequest.result;
@@ -54,22 +72,24 @@ window.onload = () => {
     db = event.target.result;
 
     db.onerror = (event) => {
-      note.appendChild(createListItem('Error loading database.'));
+      note.appendChild(createListItem("Error loading database."));
     };
 
     // Create an objectStore for this database
-    const objectStore = db.createObjectStore('toDoList', { keyPath: 'taskTitle' });
+    const objectStore = db.createObjectStore("toDoList", {
+      keyPath: "taskTitle",
+    });
 
     // Define what data items the objectStore will contain
-    objectStore.createIndex('hours', 'hours', { unique: false });
-    objectStore.createIndex('minutes', 'minutes', { unique: false });
-    objectStore.createIndex('day', 'day', { unique: false });
-    objectStore.createIndex('month', 'month', { unique: false });
-    objectStore.createIndex('year', 'year', { unique: false });
+    objectStore.createIndex("hours", "hours", { unique: false });
+    objectStore.createIndex("minutes", "minutes", { unique: false });
+    objectStore.createIndex("day", "day", { unique: false });
+    objectStore.createIndex("month", "month", { unique: false });
+    objectStore.createIndex("year", "year", { unique: false });
 
-    objectStore.createIndex('notified', 'notified', { unique: false });
+    objectStore.createIndex("notified", "notified", { unique: false });
 
-    note.appendChild(createListItem('Object store created.'));
+    note.appendChild(createListItem("Object store created."));
   };
 
   function displayData() {
@@ -80,40 +100,41 @@ window.onload = () => {
     }
 
     // Open our object store and then get a cursor list of all the different data items in the IDB to iterate through
-    const objectStore = db.transaction('toDoList').objectStore('toDoList');
+    const objectStore = db.transaction("toDoList").objectStore("toDoList");
     objectStore.openCursor().onsuccess = (event) => {
       const cursor = event.target.result;
       // Check if there are no (more) cursor items to iterate through
       if (!cursor) {
         // No more items to iterate through, we quit.
-        note.appendChild(createListItem('Entries all displayed.'));
+        note.appendChild(createListItem("Entries all displayed."));
         return;
       }
-      
+
       // Check which suffix the deadline day of the month needs
-      const { hours, minutes, day, month, year, notified, taskTitle } = cursor.value;
+      const { hours, minutes, day, month, year, notified, taskTitle } =
+        cursor.value;
       const ordDay = ordinal(day);
 
       // Build the to-do list entry and put it into the list item.
       const toDoText = `${taskTitle} — ${hours}:${minutes}, ${month} ${ordDay} ${year}.`;
       const listItem = createListItem(toDoText);
 
-      if (notified === 'yes') {
-        listItem.style.textDecoration = 'line-through';
-        listItem.style.color = 'rgba(255, 0, 0, 0.5)';
+      if (notified === "yes") {
+        listItem.style.textDecoration = "line-through";
+        listItem.style.color = "rgba(255, 0, 0, 0.5)";
       }
 
       // Put the item item inside the task list
       taskList.appendChild(listItem);
 
       // Create a delete button inside each list item,
-      const deleteButton = document.createElement('button');
+      const deleteButton = document.createElement("button");
       listItem.appendChild(deleteButton);
-      deleteButton.textContent = 'X';
-      
+      deleteButton.textContent = "X";
+
       // Set a data attribute on our delete button to associate the task it relates to.
-      deleteButton.setAttribute('data-task', taskTitle);
-      
+      deleteButton.setAttribute("data-task", taskTitle);
+
       // Associate action (deletion) when clicked
       deleteButton.onclick = (event) => {
         deleteItem(event);
@@ -122,10 +143,10 @@ window.onload = () => {
       // continue on to the next item in the cursor
       cursor.continue();
     };
-  };
+  }
 
   // Add listener for clicking the submit button
-  taskForm.addEventListener('submit', addData, false);
+  taskForm.addEventListener("submit", addData, false);
 
   function addData(e) {
     // Prevent default, as we don't want the form to submit in the conventional way
@@ -133,22 +154,39 @@ window.onload = () => {
 
     // Stop the form submitting if any values are left empty.
     // This should never happen as there is the required attribute
-    if (title.value === '' || hours.value === null || minutes.value === null || day.value === '' || month.value === '' || year.value === null) {
-      note.appendChild(createListItem('Data not submitted — form incomplete.'));
+    if (
+      title.value === "" ||
+      hours.value === null ||
+      minutes.value === null ||
+      day.value === "" ||
+      month.value === "" ||
+      year.value === null
+    ) {
+      note.appendChild(createListItem("Data not submitted — form incomplete."));
       return;
     }
-    
+
     // Grab the values entered into the form fields and store them in an object ready for being inserted into the IndexedDB
     const newItem = [
-      { taskTitle: title.value, hours: hours.value, minutes: minutes.value, day: day.value, month: month.value, year: year.value, notified: 'no' },
+      {
+        taskTitle: title.value,
+        hours: hours.value,
+        minutes: minutes.value,
+        day: day.value,
+        month: month.value,
+        year: year.value,
+        notified: "no",
+      },
     ];
 
     // Open a read/write DB transaction, ready for adding the data
-    const transaction = db.transaction(['toDoList'], 'readwrite');
+    const transaction = db.transaction(["toDoList"], "readwrite");
 
     // Report on the success of the transaction completing, when everything is done
     transaction.oncomplete = () => {
-      note.appendChild(createListItem('Transaction completed: database modification finished.'));
+      note.appendChild(
+        createListItem("Transaction completed: database modification finished.")
+      );
 
       // Update the display of data to show the newly added item, by running displayData() again.
       displayData();
@@ -156,11 +194,15 @@ window.onload = () => {
 
     // Handler for any unexpected error
     transaction.onerror = () => {
-      note.appendChild(createListItem(`Transaction not opened due to error: ${transaction.error}`));
+      note.appendChild(
+        createListItem(
+          `Transaction not opened due to error: ${transaction.error}`
+        )
+      );
     };
 
     // Call an object store that's already been added to the database
-    const objectStore = transaction.objectStore('toDoList');
+    const objectStore = transaction.objectStore("toDoList");
     console.log(objectStore.indexNames);
     console.log(objectStore.keyPath);
     console.log(objectStore.name);
@@ -170,29 +212,28 @@ window.onload = () => {
     // Make a request to add our newItem object to the object store
     const objectStoreRequest = objectStore.add(newItem[0]);
     objectStoreRequest.onsuccess = (event) => {
-
       // Report the success of our request
       // (to detect whether it has been succesfully
       // added to the database, you'd look at transaction.oncomplete)
-      note.appendChild(createListItem('Request successful.'));
+      note.appendChild(createListItem("Request successful."));
 
       // Clear the form, ready for adding the next entry
-      title.value = '';
+      title.value = "";
       hours.value = null;
       minutes.value = null;
-      day.value = '01';
-      month.value = 'January';
-      year.value = 2026;
+      day.value = "01";
+      month.value = "January";
+      year.value = new Date().getFullYear();
     };
-  };
+  }
 
   function deleteItem(event) {
     // Retrieve the name of the task we want to delete
-    const dataTask = event.target.getAttribute('data-task');
+    const dataTask = event.target.getAttribute("data-task");
 
     // Open a database transaction and delete the task, finding it by the name we retrieved above
-    const transaction = db.transaction(['toDoList'], 'readwrite');
-    transaction.objectStore('toDoList').delete(dataTask);
+    const transaction = db.transaction(["toDoList"], "readwrite");
+    transaction.objectStore("toDoList").delete(dataTask);
 
     // Report that the data item has been deleted
     transaction.oncomplete = () => {
@@ -200,15 +241,18 @@ window.onload = () => {
       event.target.parentNode.parentNode.removeChild(event.target.parentNode);
       note.appendChild(createListItem(`Task "${dataTask}" deleted.`));
     };
-  };
+  }
 
   // Check whether the deadline for each task is up or not, and responds appropriately
   function checkDeadlines() {
     // First of all check whether notifications are enabled or denied
-    if (Notification.permission === 'denied' || Notification.permission === 'default') {
-      notificationBtn.style.display = 'block';
+    if (
+      Notification.permission === "denied" ||
+      Notification.permission === "default"
+    ) {
+      notificationBtn.style.display = "block";
     } else {
-      notificationBtn.style.display = 'none';
+      notificationBtn.style.display = "none";
     }
 
     // Grab the current time and date
@@ -222,18 +266,22 @@ window.onload = () => {
     const yearCheck = now.getFullYear(); // Do not use getYear() that is deprecated.
 
     // Open a new transaction
-    const objectStore = db.transaction(['toDoList'], 'readwrite').objectStore('toDoList');
-    
+    const objectStore = db
+      .transaction(["toDoList"], "readwrite")
+      .objectStore("toDoList");
+
     // Open a cursor to iterate through all the data items in the IndexedDB
     objectStore.openCursor().onsuccess = (event) => {
       const cursor = event.target.result;
       if (!cursor) return;
-      const { hours, minutes, day, month, year, notified, taskTitle } = cursor.value;
+      const { hours, minutes, day, month, year, notified, taskTitle } =
+        cursor.value;
 
       // convert the month names we have installed in the IDB into a month number that JavaScript will understand.
       // The JavaScript date object creates month values as a number between 0 and 11.
       const monthNumber = MONTHS.indexOf(month);
-      if (monthNumber === -1) throw new Error('Incorrect month entered in database.');
+      if (monthNumber === -1)
+        throw new Error("Incorrect month entered in database.");
 
       // Check if the current hours, minutes, day, month and year values match the stored values for each task.
       // The parseInt() function transforms the value from a string to a number for comparison
@@ -243,10 +291,10 @@ window.onload = () => {
       matched &&= parseInt(day) === dayCheck;
       matched &&= parseInt(monthNumber) === monthCheck;
       matched &&= parseInt(year) === yearCheck;
-      if (matched && notified === 'no') {
+      if (matched && notified === "no") {
         // If the numbers all do match, run the createNotification() function to create a system notification
         // but only if the permission is set
-        if (Notification.permission === 'granted') {
+        if (Notification.permission === "granted") {
           createNotification(taskTitle);
         }
       }
@@ -254,28 +302,31 @@ window.onload = () => {
       // Move on to the next cursor item
       cursor.continue();
     };
-  };
+  }
 
   // Ask for permission when the 'Enable notifications' button is clicked
   function askNotificationPermission() {
     // Function to actually ask the permissions
     function handlePermission(permission) {
       // Whatever the user answers, we make sure Chrome stores the information
-      if (!Reflect.has(Notification, 'permission')) {
+      if (!Reflect.has(Notification, "permission")) {
         Notification.permission = permission;
       }
 
       // Set the button to shown or hidden, depending on what the user answers
-      if (Notification.permission === 'denied' || Notification.permission === 'default') {
-        notificationBtn.style.display = 'block';
+      if (
+        Notification.permission === "denied" ||
+        Notification.permission === "default"
+      ) {
+        notificationBtn.style.display = "block";
       } else {
-        notificationBtn.style.display = 'none';
+        notificationBtn.style.display = "none";
       }
-    };
+    }
 
     // Check if the browser supports notifications
-    if (!Reflect.has(window, 'Notification')) {
-      console.log('This browser does not support notifications.');
+    if (!Reflect.has(window, "Notification")) {
+      console.log("This browser does not support notifications.");
     } else {
       if (checkNotificationPromise()) {
         Notification.requestPermission().then(handlePermission);
@@ -283,41 +334,46 @@ window.onload = () => {
         Notification.requestPermission(handlePermission);
       }
     }
-  };
+  }
 
   // Check whether browser supports the promise version of requestPermission()
   // Safari only supports the old callback-based version
   function checkNotificationPromise() {
     try {
       Notification.requestPermission().then();
-    } catch(e) {
+    } catch (e) {
       return false;
     }
 
     return true;
-  };
+  }
 
   // Wire up notification permission functionality to 'Enable notifications' button
-  notificationBtn.addEventListener('click', askNotificationPermission);
+  notificationBtn.addEventListener("click", askNotificationPermission);
 
   function createListItem(contents) {
-    const listItem = document.createElement('li');
+    const listItem = document.createElement("li");
     listItem.textContent = contents;
     return listItem;
-  };
+  }
 
   // Create a notification with the given title
   function createNotification(title) {
     // Create and show the notification
-    const img = '/to-do-notifications/img/icon-128.png';
+    const img = "/to-do-notifications/img/icon-128.png";
     const text = `HEY! Your task "${title}" is now overdue.`;
-    const notification = new Notification('To do list', { body: text, icon: img });
+    const notification = new Notification("To do list", {
+      body: text,
+      icon: img,
+    });
 
     // We need to update the value of notified to 'yes' in this particular data object, so the
     // notification won't be set off on it again
 
     // First open up a transaction
-    const objectStore = db.transaction(['toDoList'], 'readwrite').objectStore('toDoList');
+    const objectStore = db
+      .transaction(["toDoList"], "readwrite")
+      .objectStore("toDoList");
 
     // Get the to-do list object that has this title as its title
     const objectStoreTitleRequest = objectStore.get(title);
@@ -327,7 +383,7 @@ window.onload = () => {
       const data = objectStoreTitleRequest.result;
 
       // Update the notified value in the object to 'yes'
-      data.notified = 'yes';
+      data.notified = "yes";
 
       // Create another request that inserts the item back into the database
       const updateTitleRequest = objectStore.put(data);
@@ -337,18 +393,18 @@ window.onload = () => {
         displayData();
       };
     };
-  };
+  }
 
   // Using a setInterval to run the checkDeadlines() function every second
   setInterval(checkDeadlines, 1000);
-}
+};
 
 // Helper function returning the day of the month followed by an ordinal (st, nd, or rd)
 function ordinal(day) {
   const n = day.toString();
   const last = n.slice(-1);
-  if (last === '1' && n !== '11') return `${n}st`;
-  if (last === '2' && n !== '12') return `${n}nd`;
-  if (last === '3' && n !== '13') return `${n}rd`;
+  if (last === "1" && n !== "11") return `${n}st`;
+  if (last === "2" && n !== "12") return `${n}nd`;
+  if (last === "3" && n !== "13") return `${n}rd`;
   return `${n}th`;
-};
+}


### PR DESCRIPTION
This is a follow up to https://github.com/mdn/dom-examples/pull/371, which was loading 2030 as the starting year in the form, picking from the first option in the HTML drop-down list.

This PR:
- Sets the year on form load to the current year as well as after a to-do entry.
- Updates the list of years in the drop-down to an ascending order.

### Motivation

To avoid future updates to this UI every time the year changes

### Additional details

The app link can be accessed at https://mdn.github.io/dom-examples/to-do-notifications/