### PR TITLE
Fix IndexedDB image preview for uploaded images

### DIFF
--- a/indexeddb-api/main.js
+++ b/indexeddb-api/main.js
@@ -187,9 +187,14 @@
           var img = $('<img id="' + img_id + '"/>');
           $(this).contents().find('body').html(img);
           var obj_url = window.URL.createObjectURL(blob);
-          $(this).contents().find('#' + img_id).attr('src', obj_url);
-          window.URL.revokeObjectURL(obj_url);
+          var imgEl = $(this).contents().find('#' + img_id);
+          // Ensure the image loads before revoking its url.
+          imgEl.load(function() {
+            window.URL.revokeObjectURL(obj_url);
+          });
+          imgEl.attr('src', obj_url);
         });
+        iframe.attr('src', 'about:blank');
       } else if (blob.type == 'application/pdf') {
         $('*').css('cursor', 'wait');
         var obj_url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
This fixes uploaded-image previews in the indexeddb-api demo.

The image preview code created an object URL, assigned it to the
image, and revoked it immediately. In practice, that could cause
the preview to fail before the image finished loading.

This change revokes the object URL after the image load event
instead, and explicitly loads about:blank in the iframe so the
existing viewer code path runs.

Scope is intentionally limited to images. PDF handling is unchanged.

Fixes #278