### PR TITLE
Fix message retrieval and variable declaration

### DIFF
--- a/web-crypto/sign-verify/ed25519.js
+++ b/web-crypto/sign-verify/ed25519.js
@@ -10,7 +10,10 @@
   */
   function getMessageEncoding() {
     const messageBox = document.querySelector("#ed25519-message");
-    let message = messageBox.value;
+
+    if(!messageBox) return null;
+    
+    const message = messageBox.value;
     let enc = new TextEncoder();
     return enc.encode(message);
   }
@@ -44,7 +47,7 @@
     signatureValue.classList.remove("valid", "invalid");
 
     let encoded = getMessageEncoding();
-    let result = await window.crypto.subtle.verify(
+    const result = await window.crypto.subtle.verify(
       "Ed25519",
       publicKey,
       signature,


### PR DESCRIPTION
Replacing let with const for variables where the value is not being mutated downstream.

Returns null if messageBox is not present to begin with.