### PR TITLE
Use focusNode/Offset instead of extentNode/Offset in EditContext example

### DIFF
--- a/edit-context/html-editor/converter.js
+++ b/edit-context/html-editor/converter.js
@@ -6,9 +6,9 @@ export function fromSelectionToOffsets(selection, editorEl) {
   const treeWalker = document.createTreeWalker(editorEl, NodeFilter.SHOW_TEXT);
 
   let anchorNodeFound = false;
-  let extentNodeFound = false;
+  let focusNodeFound = false;
   let anchorOffset = 0;
-  let extentOffset = 0;
+  let focusOffset = 0;
 
   while (treeWalker.nextNode()) {
     const node = treeWalker.currentNode;
@@ -17,24 +17,24 @@ export function fromSelectionToOffsets(selection, editorEl) {
       anchorOffset += selection.anchorOffset;
     }
 
-    if (node === selection.extentNode) {
-      extentNodeFound = true;
-      extentOffset += selection.extentOffset;
+    if (node === selection.focusNode) {
+      focusNodeFound = true;
+      focusOffset += selection.focusOffset;
     }
 
     if (!anchorNodeFound) {
       anchorOffset += node.textContent.length;
     }
-    if (!extentNodeFound) {
-      extentOffset += node.textContent.length;
+    if (!focusNodeFound) {
+      focusOffset += node.textContent.length;
     }
   }
 
-  if (!anchorNodeFound || !extentNodeFound) {
+  if (!anchorNodeFound || !focusNodeFound) {
     return null;
   }
 
-  return { start: anchorOffset, end: extentOffset };
+  return { start: anchorOffset, end: focusOffset };
 }
 
 // The EditContext object only knows about a plain text string and about
@@ -47,8 +47,8 @@ export function fromOffsetsToSelection(start, end, editorEl) {
   let offset = 0;
   let anchorNode = null;
   let anchorOffset = 0;
-  let extentNode = null;
-  let extentOffset = 0;
+  let focusNode = null;
+  let focusOffset = 0;
 
   while (treeWalker.nextNode()) {
     const node = treeWalker.currentNode;
@@ -58,19 +58,19 @@ export function fromOffsetsToSelection(start, end, editorEl) {
       anchorOffset = start - offset;
     }
 
-    if (!extentNode && offset + node.textContent.length >= end) {
-      extentNode = node;
-      extentOffset = end - offset;
+    if (!focusNode && offset + node.textContent.length >= end) {
+      focusNode = node;
+      focusOffset = end - offset;
     }
 
-    if (anchorNode && extentNode) {
+    if (anchorNode && focusNode) {
       break;
     }
 
     offset += node.textContent.length;
   }
 
-  return { anchorNode, anchorOffset, extentNode, extentOffset };
+  return { anchorNode, anchorOffset, focusNode, focusOffset };
 }
 
 // The EditContext object only knows about character offsets. But out editor

--- a/edit-context/html-editor/editor.js
+++ b/edit-context/html-editor/editor.js
@@ -102,11 +102,11 @@ if (IS_CUSTOM_HIGHLIGHT_SUPPORTED) {
     // It was lost when we updated the DOM.
     // The EditContext API gives us the selection as text offsets.
     // Convert it into a DOM selection.
-    const { anchorNode, anchorOffset, extentNode, extentOffset } =
+    const { anchorNode, anchorOffset, focusNode, focusOffset } =
       fromOffsetsToSelection(selectionStart, selectionEnd, editorEl);
     document
       .getSelection()
-      .setBaseAndExtent(anchorNode, anchorOffset, extentNode, extentOffset);
+      .setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
   }
 
   // Listen to the EditContext's textupdate event.
@@ -171,7 +171,7 @@ if (IS_CUSTOM_HIGHLIGHT_SUPPORTED) {
       // Add a range to the Highlight object.
       const range = document.createRange();
       range.setStart(selection.anchorNode, selection.anchorOffset);
-      range.setEnd(selection.extentNode, selection.extentOffset);
+      range.setEnd(selection.focusNode, selection.focusOffset);
       highlight.add(range);
     }
   }


### PR DESCRIPTION
I have been working on adding EditContext support to Firefox and the EditContext example here has been useful for testing things out. :)
But unfortunately it uses the non-standard `Selection.extentNode`/`Offset` which is not supported on Firefox. Those are now just aliases for the standard `focusNode`/`Offset` see [here](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/dom_selection.cc;drc=8588b53b02b80dba2d065324bea2ea429bc69b37;l=162) and [here](https://github.com/WebKit/WebKit/blob/1ae0cde7d58ca3346d2b5c4f15ba95701bc36958/Source/WebCore/page/DOMSelection.idl#L78)), so it would be nice to use them instead.