### PR TITLE
Specify position-anchor: auto in the popover-hint example.

### DIFF
--- a/popover-api/popover-hint/index.css
+++ b/popover-api/popover-hint/index.css
@@ -65,6 +65,8 @@ body {
   position: absolute;
   bottom: calc(anchor(top) + 20px);
   justify-self: anchor-center;
+  /* Not required if using position-area. */
+  position-anchor: auto;
   margin: 0;
 
   width: 200px;


### PR DESCRIPTION
Due to back-compat issues [1], popovers don't automatically look for the implicit anchor unless either `position-anchor: auto` is specified, or `position-area` is not `none` (With the default value of `position-anchor: normal`).

This example, because it uses `anchor()` and `anchor-center`, requires explicitly specifying `position-anchor: auto`, as of Bug 2030351.

[1]: https://github.com/w3c/csswg-drafts/issues/13067