### PR TITLE
Add scroll-promises examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Do not specify supported browsers and their versions in code comments or prose, 
 
 - The "screenleft-screentop" directory contains a demo to show how you could use the [Window.screenLeft](https://developer.mozilla.org/docs/Web/API/Window/screenLeft) and [Window.screenTop](https://developer.mozilla.org/docs/Web/API/Window/screenTop) properties to draw a circle on a canvas that always stays in the same physical place on the screen when you move your browser window. [Run the demo live](https://mdn.github.io/dom-examples/screenleft-screentop/).
 
+- The "scroll-promises" directory contains demos illustrating usage of the promise-returning scroll methods (for example, `Element.scroll()`). See the [scroll promises README](scroll-promises/README.md) for more information.
+
 - The "scrolltooptions" directory contains a demo to show how you could use the [ScrollToOptions](https://developer.mozilla.org/docs/Web/API/ScrollToOptions) dictionary along with the [Window.ScrollTo()](https://developer.mozilla.org/docs/Web/API/Window/scrollTo) method to programmatically scroll a web page. [Run the demo live](https://mdn.github.io/dom-examples/scrolltooptions/).
 
 - The "server-sent-events" directory contains a very basic SSE demo that uses PHP to create the server. You can find more information in our [Using server-sent events](https://developer.mozilla.org/docs/Web/API/Server-sent_events/Using_server-sent_events) article. To run the demo you'll need to serve the files from a server that supports PHP; [MAMP](https://www.mamp.info/en/) is a good PHP test server environment.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Do not specify supported browsers and their versions in code comments or prose, 
 
 - The "screenleft-screentop" directory contains a demo to show how you could use the [Window.screenLeft](https://developer.mozilla.org/docs/Web/API/Window/screenLeft) and [Window.screenTop](https://developer.mozilla.org/docs/Web/API/Window/screenTop) properties to draw a circle on a canvas that always stays in the same physical place on the screen when you move your browser window. [Run the demo live](https://mdn.github.io/dom-examples/screenleft-screentop/).
 
-- The "scroll-promises" directory contains demos illustrating usage of the promise-returning scroll methods (for example, `Element.scroll()`). See the [scroll promises README](scroll-promises/README.md) for more information.
+- The "scroll-promises" directory contains demos illustrating usage of the promise-returning scroll methods (for example, `Element.scroll()`). See the [scroll promises README](scroll-promises/README.md) for more information.  Run the demos live: [Element methods](https://mdn.github.io/dom-examples/scroll-promises/element-methods/), [Window methods](https://mdn.github.io/dom-examples/scroll-promises/window-methods/).
 
 - The "scrolltooptions" directory contains a demo to show how you could use the [ScrollToOptions](https://developer.mozilla.org/docs/Web/API/ScrollToOptions) dictionary along with the [Window.ScrollTo()](https://developer.mozilla.org/docs/Web/API/Window/scrollTo) method to programmatically scroll a web page. [Run the demo live](https://mdn.github.io/dom-examples/scrolltooptions/).
 

--- a/scroll-promises/README.md
+++ b/scroll-promises/README.md
@@ -1,0 +1,10 @@
+# MDN scroll promises examples
+
+This set of examples demonstrates usage of the promise-returning versions of the `Window` and `Element` scroll methods. In each case, the promise can be used to respond to a scroll operation finishing, which is useful for smooth scrolling operations (for example, created using the [`scroll-behavior`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-behavior) CSS property).
+
+## Examples
+
+- [Element methods](element-methods/): Provides a scrolling container full of content, and a toolbar containing buttons that trigger various scrolling operations using [`Element.scroll()`](https://developer.mozilla.org/docs/Web/API/Element/scroll), [`Element.scrollBy()`](https://developer.mozilla.org/docs/Web/API/Element/scrollBy), [`Element.scrollIntoView()`](https://developer.mozilla.org/docs/Web/API/Element/scrollIntoView), and [`Element.scrollTo()`](https://developer.mozilla.org/docs/Web/API/Element/scrollTo). [See the element methods demo live](https://mdn.github.io/dom-examples/scroll-promises/element-methods/).
+- [Window methods](window-methods/): Provides a window full of content, and a toolbar containing buttons that trigger various scrolling operations using [`Window.scroll()`](https://developer.mozilla.org/docs/Web/API/Window/scroll), [`Window.scrollBy()`](https://developer.mozilla.org/docs/Web/API/Window/scrollBy), and [`Window.scrollTo()`](https://developer.mozilla.org/docs/Web/API/Window/scrollTo). [See the window methods demo live](https://mdn.github.io/dom-examples/scroll-promises/window-methods/).
+
+In both cases, `scroll-behavior: smooth` is set on the scrolling element to implement smooth scrolling operations. Each button event handler applies a fade-out animation to the toolbar, then scrolls the content, then applies a fade-in animation to the toolbar once the scroll operation promise resolves. The result is that toolbar fades out when a button is pressed, then fades in again once scrolling is finished.

--- a/scroll-promises/element-methods/index.html
+++ b/scroll-promises/element-methods/index.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Scroll promises</title>
+    <link href="style.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+  </head>
+  <body>
+    <div>
+      <button class="scroll">scroll() to 1000</button>
+      <button class="scrollto">scrollTo() top</button>
+      <button class="scrollby">scrollBy() 200</button>
+      <button class="scrollintoview">Scroll last &lt;p&gt; into view</button>
+    </div>
+
+    <section>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc malesuada
+        blandit odio a sodales. Nunc feugiat, sapien ac aliquam consectetur, leo
+        tortor gravida nisl, in congue risus orci a arcu. Morbi sollicitudin,
+        arcu nec faucibus semper, lectus metus scelerisque justo, maximus
+        molestie justo libero in nisl. Aliquam erat volutpat. Sed ullamcorper
+        ullamcorper lacus quis placerat. Vivamus imperdiet elit lacus, sit amet
+        commodo metus convallis sit amet. Donec laoreet nulla non ipsum
+        malesuada, a maximus nisi volutpat. Vivamus scelerisque posuere neque.
+        Phasellus tincidunt, diam sollicitudin pulvinar feugiat, mauris nulla
+        aliquam nisl, nec semper urna dui non sapien. Maecenas tincidunt turpis
+        leo, vitae luctus leo placerat eget. Nunc posuere, diam sed luctus
+        lobortis, nulla ligula pretium risus, semper congue dolor urna sed quam.
+      </p>
+
+      <p>
+        Praesent vitae pellentesque nulla. Suspendisse volutpat dapibus nunc et
+        dignissim. Suspendisse mattis tempus aliquet. Duis et sagittis tellus.
+        In at mattis diam, non efficitur ante. Class aptent taciti sociosqu ad
+        litora torquent per conubia nostra, per inceptos himenaeos. Vivamus
+        consequat odio ligula, non venenatis turpis ornare id. Quisque sed neque
+        quis enim congue porta et congue justo. Duis dignissim libero at quam
+        pretium eleifend.
+      </p>
+
+      <p>
+        Vivamus porta enim a est faucibus, id dictum nunc sagittis. Duis porta
+        diam diam, id mattis erat sagittis ac. Duis ullamcorper volutpat
+        posuere. Nunc quis euismod risus. In hac habitasse platea dictumst. Sed
+        nec congue est. Phasellus sed erat est. Fusce accumsan sem in velit
+        feugiat dignissim. Cras vestibulum metus augue, ut bibendum quam viverra
+        et. Fusce et sodales ligula. Sed dictum eros vel blandit pellentesque.
+      </p>
+
+      <p>
+        Quisque mollis mollis justo id ullamcorper. Curabitur ultricies leo non
+        posuere aliquet. Suspendisse lobortis nunc sed augue aliquet fringilla.
+        In hac habitasse platea dictumst. Nam elit enim, malesuada vel est non,
+        ultricies viverra nisi. Donec faucibus, ipsum quis bibendum varius, nunc
+        risus maximus nibh, sed pharetra turpis leo non diam. Etiam hendrerit
+        dignissim arcu vel laoreet. Etiam nec mauris bibendum lacus viverra
+        porttitor. Aenean rhoncus orci nec est rhoncus elementum. Aenean ipsum
+        ante, accumsan ut elementum sit amet, fringilla ac risus. Aliquam
+        fringilla a leo eget ullamcorper. Quisque dolor velit, fringilla et nibh
+        nec, sagittis vulputate urna. Fusce consectetur sapien ac tortor
+        elementum scelerisque.
+      </p>
+
+      <p>
+        Pellentesque vehicula lacus purus, vitae hendrerit est placerat nec.
+        Quisque in auctor ante, vel iaculis augue. Sed volutpat est at nisl
+        tincidunt blandit. Mauris sit amet nisi nec neque condimentum tempus a
+        porttitor ex. Curabitur rutrum cursus libero eu interdum. Nulla egestas
+        gravida lacus, nec auctor ex molestie id. Morbi sodales nibh neque.
+        Nullam viverra nisi vel ipsum efficitur, rutrum convallis mauris
+        ultricies.
+      </p>
+
+      <p>
+        Mauris non ex felis. Vivamus a nibh sit amet ante sagittis commodo. Ut
+        non consequat nibh. Maecenas a odio vitae dui tristique malesuada.
+        Aliquam pellentesque mi nec hendrerit elementum. Sed nec ipsum ac enim
+        lobortis euismod. Morbi iaculis auctor lorem id accumsan. Curabitur
+        scelerisque ex quis ante elementum, sit amet convallis nibh rutrum. Duis
+        elementum leo nibh, quis efficitur arcu efficitur eu. Vivamus posuere
+        lacinia tristique.
+      </p>
+
+      <p>
+        Fusce in placerat risus, tempus cursus diam. Mauris vulputate pharetra
+        est, non vehicula turpis pretium finibus. Donec faucibus lorem sed metus
+        venenatis, euismod viverra ligula sodales. Morbi hendrerit odio a congue
+        sagittis. Nunc dictum maximus ex, id eleifend lectus dapibus ut.
+        Pellentesque nec lectus et massa vulputate tincidunt. Vestibulum luctus
+        eu lorem nec dapibus. Praesent faucibus, eros vitae accumsan luctus,
+        turpis nibh feugiat urna, vitae iaculis leo libero vel orci. Donec
+        venenatis, ipsum sed placerat bibendum, urna orci gravida est, bibendum
+        eleifend sem neque vitae odio. Duis id nunc ligula. Curabitur et mauris
+        convallis, porttitor ex quis, molestie lacus. Proin ultrices ligula eget
+        malesuada aliquet. Aliquam convallis at risus sit amet porttitor. Etiam
+        finibus iaculis accumsan. Cras a hendrerit metus. Quisque eget odio vel
+        neque tristique faucibus.
+      </p>
+
+      <p>
+        Integer interdum dui vehicula tellus consectetur suscipit. Quisque
+        fermentum, nisi ut molestie imperdiet, tellus massa convallis justo, ut
+        consectetur massa sem nec nunc. Nam tempus commodo metus ut feugiat.
+        Mauris tellus ante, tempor sit amet erat et, rutrum sagittis augue. Ut
+        tempor volutpat arcu ullamcorper ullamcorper. Proin id nisi odio. Donec
+        dui mauris, auctor sit amet dapibus eu, hendrerit sit amet turpis.
+        Quisque pretium turpis in lectus tempor convallis. Ut dolor risus,
+        tempor eget rhoncus sit amet, tristique a lacus. Sed nisi nisl,
+        pellentesque vel semper id, vulputate in nulla. Pellentesque semper
+        vitae ipsum sed suscipit. Nunc vehicula, dui consequat ultrices
+        convallis, orci libero porttitor turpis, sed ornare dolor nisl id enim.
+        Vestibulum non pharetra erat, sed iaculis nisi. Suspendisse auctor
+        maximus volutpat. Sed id condimentum mauris.
+      </p>
+
+      <p>
+        Suspendisse libero eros, lobortis eu varius dictum, auctor sed dolor.
+        Etiam lobortis, quam nec interdum rhoncus, odio mauris malesuada neque,
+        vestibulum porttitor sem dui sit amet ante. Aliquam posuere nisi nunc,
+        at molestie turpis scelerisque eu. Nunc sed nunc vel magna semper
+        tempor. In hac habitasse platea dictumst. Quisque lacus dui, varius at
+        lobortis eget, venenatis a tortor. Nulla vitae gravida diam. Sed nisl
+        lorem, consectetur vitae urna id, mattis auctor tortor. Vestibulum ante
+        ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;
+        Maecenas faucibus iaculis quam, non molestie dui commodo in.
+      </p>
+
+      <p id="end">
+        Nulla commodo tellus tortor, egestas aliquam diam luctus vitae. Aenean
+        sed nisl felis. Phasellus sit amet quam porta, pulvinar erat in, viverra
+        neque. Donec tortor lorem, efficitur in mi eu, tempus gravida justo.
+        Suspendisse efficitur cursus risus, et laoreet ante ultricies et.
+        Suspendisse potenti. Proin hendrerit in magna vel ultricies. Etiam
+        lobortis aliquet elementum. Vivamus eleifend, quam sit amet varius
+        convallis, enim est gravida tellus, eu rhoncus mi ipsum vitae nisl. Cras
+        convallis diam sit amet odio facilisis efficitur. Morbi dignissim lorem
+        magna, vehicula tincidunt mi sagittis a.
+      </p>
+    </section>
+  </body>
+</html>

--- a/scroll-promises/element-methods/index.html
+++ b/scroll-promises/element-methods/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Scroll promises</title>
+    <title>Scroll promises — Element methods</title>
     <link href="style.css" rel="stylesheet" />
     <script defer src="index.js"></script>
   </head>

--- a/scroll-promises/element-methods/index.js
+++ b/scroll-promises/element-methods/index.js
@@ -7,38 +7,63 @@ const toolbar = document.querySelector("div");
 const section = document.querySelector("section");
 const end = document.querySelector("#end");
 
-scrollBtn.addEventListener("click", async () => {
-  toolbar.className = "fade-out";
-  const result = await section.scroll(0, 1000);
-  console.log(
-    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-  );
-  toolbar.className = "fade-in";
-});
+function supportsScrollPromises() {
+  const test = section.scroll(0, 0);
+  return test instanceof Promise;
+}
 
-scrollToBtn.addEventListener("click", async () => {
-  toolbar.className = "fade-out";
-  const result = await section.scrollTo(0, 0);
-  console.log(
-    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-  );
-  toolbar.className = "fade-in";
-});
+const supports = supportsScrollPromises();
 
-scrollByBtn.addEventListener("click", async () => {
-  toolbar.className = "fade-out";
-  const result = await section.scrollBy(0, 200);
-  console.log(
-    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-  );
-  toolbar.className = "fade-in";
-});
+if (supports) {
+  scrollBtn.addEventListener("click", async () => {
+    toolbar.className = "fade-out";
+    const result = await section.scroll(0, 1000);
+    console.log(
+      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+    );
+    toolbar.className = "fade-in";
+  });
 
-scrollIntoViewBtn.addEventListener("click", async () => {
-  toolbar.className = "fade-out";
-  const result = await end.scrollIntoView();
-  console.log(
-    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-  );
-  toolbar.className = "fade-in";
-});
+  scrollToBtn.addEventListener("click", async () => {
+    toolbar.className = "fade-out";
+    const result = await section.scrollTo(0, 0);
+    console.log(
+      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+    );
+    toolbar.className = "fade-in";
+  });
+
+  scrollByBtn.addEventListener("click", async () => {
+    toolbar.className = "fade-out";
+    const result = await section.scrollBy(0, 200);
+    console.log(
+      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+    );
+    toolbar.className = "fade-in";
+  });
+
+  scrollIntoViewBtn.addEventListener("click", async () => {
+    toolbar.className = "fade-out";
+    const result = await end.scrollIntoView();
+    console.log(
+      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+    );
+    toolbar.className = "fade-in";
+  });
+} else {
+  scrollBtn.addEventListener("click", () => {
+    section.scroll(0, 1000);
+  });
+
+  scrollToBtn.addEventListener("click", () => {
+    section.scrollTo(0, 0);
+  });
+
+  scrollByBtn.addEventListener("click", () => {
+    section.scrollBy(0, 200);
+  });
+
+  scrollIntoViewBtn.addEventListener("click", () => {
+    end.scrollIntoView();
+  });
+}

--- a/scroll-promises/element-methods/index.js
+++ b/scroll-promises/element-methods/index.js
@@ -9,28 +9,36 @@ const end = document.querySelector("#end");
 
 scrollBtn.addEventListener("click", async () => {
   toolbar.className = "fade-out";
-  await section.scroll(0, 1000);
-  console.log("Scroll finished");
+  const result = await section.scroll(0, 1000);
+  console.log(
+    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+  );
   toolbar.className = "fade-in";
 });
 
 scrollToBtn.addEventListener("click", async () => {
   toolbar.className = "fade-out";
-  await section.scrollTo(0, 0);
-  console.log("Scroll finished");
+  const result = await section.scrollTo(0, 0);
+  console.log(
+    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+  );
   toolbar.className = "fade-in";
 });
 
 scrollByBtn.addEventListener("click", async () => {
   toolbar.className = "fade-out";
-  await section.scrollBy(0, 200);
-  console.log("Scroll finished");
+  const result = await section.scrollBy(0, 200);
+  console.log(
+    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+  );
   toolbar.className = "fade-in";
 });
 
 scrollIntoViewBtn.addEventListener("click", async () => {
   toolbar.className = "fade-out";
-  await end.scrollIntoView();
-  console.log("Scroll finished");
+  const result = await end.scrollIntoView();
+  console.log(
+    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+  );
   toolbar.className = "fade-in";
 });

--- a/scroll-promises/element-methods/index.js
+++ b/scroll-promises/element-methods/index.js
@@ -1,0 +1,36 @@
+const scrollBtn = document.querySelector(".scroll");
+const scrollToBtn = document.querySelector(".scrollto");
+const scrollByBtn = document.querySelector(".scrollby");
+const scrollIntoViewBtn = document.querySelector(".scrollintoview");
+
+const toolbar = document.querySelector("div");
+const section = document.querySelector("section");
+const end = document.querySelector("#end");
+
+scrollBtn.addEventListener("click", async () => {
+  toolbar.className = "fade-out";
+  await section.scroll(0, 1000);
+  console.log("Scroll finished");
+  toolbar.className = "fade-in";
+});
+
+scrollToBtn.addEventListener("click", async () => {
+  toolbar.className = "fade-out";
+  await section.scrollTo(0, 0);
+  console.log("Scroll finished");
+  toolbar.className = "fade-in";
+});
+
+scrollByBtn.addEventListener("click", async () => {
+  toolbar.className = "fade-out";
+  await section.scrollBy(0, 200);
+  console.log("Scroll finished");
+  toolbar.className = "fade-in";
+});
+
+scrollIntoViewBtn.addEventListener("click", async () => {
+  toolbar.className = "fade-out";
+  await end.scrollIntoView();
+  console.log("Scroll finished");
+  toolbar.className = "fade-in";
+});

--- a/scroll-promises/element-methods/index.js
+++ b/scroll-promises/element-methods/index.js
@@ -12,42 +12,41 @@ function supportsScrollPromises() {
   return test instanceof Promise;
 }
 
+function isInterrupted(interrupted) {
+  console.log(`Scroll finished;${interrupted ? " " : " not "}interrupted`);
+  if (interrupted) {
+    alert("Scroll interrupted!");
+  }
+}
+
 const supports = supportsScrollPromises();
 
 if (supports) {
   scrollBtn.addEventListener("click", async () => {
     toolbar.className = "fade-out";
     const result = await section.scroll(0, 1000);
-    console.log(
-      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-    );
+    isInterrupted(result.interrupted);
     toolbar.className = "fade-in";
   });
 
   scrollToBtn.addEventListener("click", async () => {
     toolbar.className = "fade-out";
     const result = await section.scrollTo(0, 0);
-    console.log(
-      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-    );
+    isInterrupted(result.interrupted);
     toolbar.className = "fade-in";
   });
 
   scrollByBtn.addEventListener("click", async () => {
     toolbar.className = "fade-out";
     const result = await section.scrollBy(0, 200);
-    console.log(
-      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-    );
+    isInterrupted(result.interrupted);
     toolbar.className = "fade-in";
   });
 
   scrollIntoViewBtn.addEventListener("click", async () => {
     toolbar.className = "fade-out";
     const result = await end.scrollIntoView();
-    console.log(
-      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-    );
+    isInterrupted(result.interrupted);
     toolbar.className = "fade-in";
   });
 } else {

--- a/scroll-promises/element-methods/style.css
+++ b/scroll-promises/element-methods/style.css
@@ -1,0 +1,57 @@
+section {
+  height: 500px;
+  border: 1px solid black;
+  padding: 20px;
+  margin-top: 60px;
+  overflow-y: scroll;
+  scroll-behavior: smooth;
+}
+
+body {
+  width: 80%;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+p {
+  font-family: sans-serif;
+  font-size: 1.3rem;
+  line-height: 1.5;
+}
+
+div {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  background: gray;
+  padding: 10px;
+}
+
+.fade-out {
+  animation: fade-out 0.3s linear both;
+}
+
+.fade-in {
+  animation: fade-in 0.3s linear both;
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}

--- a/scroll-promises/window-methods/index.html
+++ b/scroll-promises/window-methods/index.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Scroll promises</title>
+    <link href="style.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+  </head>
+  <body>
+    <div>
+      <button class="scroll">scroll() to 1000</button>
+      <button class="scrollto">scrollTo() top</button>
+      <button class="scrollby">scrollBy() 200</button>
+    </div>
+
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc malesuada
+      blandit odio a sodales. Nunc feugiat, sapien ac aliquam consectetur, leo
+      tortor gravida nisl, in congue risus orci a arcu. Morbi sollicitudin, arcu
+      nec faucibus semper, lectus metus scelerisque justo, maximus molestie
+      justo libero in nisl. Aliquam erat volutpat. Sed ullamcorper ullamcorper
+      lacus quis placerat. Vivamus imperdiet elit lacus, sit amet commodo metus
+      convallis sit amet. Donec laoreet nulla non ipsum malesuada, a maximus
+      nisi volutpat. Vivamus scelerisque posuere neque. Phasellus tincidunt,
+      diam sollicitudin pulvinar feugiat, mauris nulla aliquam nisl, nec semper
+      urna dui non sapien. Maecenas tincidunt turpis leo, vitae luctus leo
+      placerat eget. Nunc posuere, diam sed luctus lobortis, nulla ligula
+      pretium risus, semper congue dolor urna sed quam.
+    </p>
+
+    <p>
+      Praesent vitae pellentesque nulla. Suspendisse volutpat dapibus nunc et
+      dignissim. Suspendisse mattis tempus aliquet. Duis et sagittis tellus. In
+      at mattis diam, non efficitur ante. Class aptent taciti sociosqu ad litora
+      torquent per conubia nostra, per inceptos himenaeos. Vivamus consequat
+      odio ligula, non venenatis turpis ornare id. Quisque sed neque quis enim
+      congue porta et congue justo. Duis dignissim libero at quam pretium
+      eleifend.
+    </p>
+
+    <p>
+      Vivamus porta enim a est faucibus, id dictum nunc sagittis. Duis porta
+      diam diam, id mattis erat sagittis ac. Duis ullamcorper volutpat posuere.
+      Nunc quis euismod risus. In hac habitasse platea dictumst. Sed nec congue
+      est. Phasellus sed erat est. Fusce accumsan sem in velit feugiat
+      dignissim. Cras vestibulum metus augue, ut bibendum quam viverra et. Fusce
+      et sodales ligula. Sed dictum eros vel blandit pellentesque.
+    </p>
+
+    <p>
+      Quisque mollis mollis justo id ullamcorper. Curabitur ultricies leo non
+      posuere aliquet. Suspendisse lobortis nunc sed augue aliquet fringilla. In
+      hac habitasse platea dictumst. Nam elit enim, malesuada vel est non,
+      ultricies viverra nisi. Donec faucibus, ipsum quis bibendum varius, nunc
+      risus maximus nibh, sed pharetra turpis leo non diam. Etiam hendrerit
+      dignissim arcu vel laoreet. Etiam nec mauris bibendum lacus viverra
+      porttitor. Aenean rhoncus orci nec est rhoncus elementum. Aenean ipsum
+      ante, accumsan ut elementum sit amet, fringilla ac risus. Aliquam
+      fringilla a leo eget ullamcorper. Quisque dolor velit, fringilla et nibh
+      nec, sagittis vulputate urna. Fusce consectetur sapien ac tortor elementum
+      scelerisque.
+    </p>
+
+    <p>
+      Pellentesque vehicula lacus purus, vitae hendrerit est placerat nec.
+      Quisque in auctor ante, vel iaculis augue. Sed volutpat est at nisl
+      tincidunt blandit. Mauris sit amet nisi nec neque condimentum tempus a
+      porttitor ex. Curabitur rutrum cursus libero eu interdum. Nulla egestas
+      gravida lacus, nec auctor ex molestie id. Morbi sodales nibh neque. Nullam
+      viverra nisi vel ipsum efficitur, rutrum convallis mauris ultricies.
+    </p>
+
+    <p>
+      Mauris non ex felis. Vivamus a nibh sit amet ante sagittis commodo. Ut non
+      consequat nibh. Maecenas a odio vitae dui tristique malesuada. Aliquam
+      pellentesque mi nec hendrerit elementum. Sed nec ipsum ac enim lobortis
+      euismod. Morbi iaculis auctor lorem id accumsan. Curabitur scelerisque ex
+      quis ante elementum, sit amet convallis nibh rutrum. Duis elementum leo
+      nibh, quis efficitur arcu efficitur eu. Vivamus posuere lacinia tristique.
+    </p>
+
+    <p>
+      Fusce in placerat risus, tempus cursus diam. Mauris vulputate pharetra
+      est, non vehicula turpis pretium finibus. Donec faucibus lorem sed metus
+      venenatis, euismod viverra ligula sodales. Morbi hendrerit odio a congue
+      sagittis. Nunc dictum maximus ex, id eleifend lectus dapibus ut.
+      Pellentesque nec lectus et massa vulputate tincidunt. Vestibulum luctus eu
+      lorem nec dapibus. Praesent faucibus, eros vitae accumsan luctus, turpis
+      nibh feugiat urna, vitae iaculis leo libero vel orci. Donec venenatis,
+      ipsum sed placerat bibendum, urna orci gravida est, bibendum eleifend sem
+      neque vitae odio. Duis id nunc ligula. Curabitur et mauris convallis,
+      porttitor ex quis, molestie lacus. Proin ultrices ligula eget malesuada
+      aliquet. Aliquam convallis at risus sit amet porttitor. Etiam finibus
+      iaculis accumsan. Cras a hendrerit metus. Quisque eget odio vel neque
+      tristique faucibus.
+    </p>
+
+    <p>
+      Integer interdum dui vehicula tellus consectetur suscipit. Quisque
+      fermentum, nisi ut molestie imperdiet, tellus massa convallis justo, ut
+      consectetur massa sem nec nunc. Nam tempus commodo metus ut feugiat.
+      Mauris tellus ante, tempor sit amet erat et, rutrum sagittis augue. Ut
+      tempor volutpat arcu ullamcorper ullamcorper. Proin id nisi odio. Donec
+      dui mauris, auctor sit amet dapibus eu, hendrerit sit amet turpis. Quisque
+      pretium turpis in lectus tempor convallis. Ut dolor risus, tempor eget
+      rhoncus sit amet, tristique a lacus. Sed nisi nisl, pellentesque vel
+      semper id, vulputate in nulla. Pellentesque semper vitae ipsum sed
+      suscipit. Nunc vehicula, dui consequat ultrices convallis, orci libero
+      porttitor turpis, sed ornare dolor nisl id enim. Vestibulum non pharetra
+      erat, sed iaculis nisi. Suspendisse auctor maximus volutpat. Sed id
+      condimentum mauris.
+    </p>
+
+    <p>
+      Suspendisse libero eros, lobortis eu varius dictum, auctor sed dolor.
+      Etiam lobortis, quam nec interdum rhoncus, odio mauris malesuada neque,
+      vestibulum porttitor sem dui sit amet ante. Aliquam posuere nisi nunc, at
+      molestie turpis scelerisque eu. Nunc sed nunc vel magna semper tempor. In
+      hac habitasse platea dictumst. Quisque lacus dui, varius at lobortis eget,
+      venenatis a tortor. Nulla vitae gravida diam. Sed nisl lorem, consectetur
+      vitae urna id, mattis auctor tortor. Vestibulum ante ipsum primis in
+      faucibus orci luctus et ultrices posuere cubilia curae; Maecenas faucibus
+      iaculis quam, non molestie dui commodo in.
+    </p>
+
+    <p>
+      Nulla commodo tellus tortor, egestas aliquam diam luctus vitae. Aenean sed
+      nisl felis. Phasellus sit amet quam porta, pulvinar erat in, viverra
+      neque. Donec tortor lorem, efficitur in mi eu, tempus gravida justo.
+      Suspendisse efficitur cursus risus, et laoreet ante ultricies et.
+      Suspendisse potenti. Proin hendrerit in magna vel ultricies. Etiam
+      lobortis aliquet elementum. Vivamus eleifend, quam sit amet varius
+      convallis, enim est gravida tellus, eu rhoncus mi ipsum vitae nisl. Cras
+      convallis diam sit amet odio facilisis efficitur. Morbi dignissim lorem
+      magna, vehicula tincidunt mi sagittis a.
+    </p>
+  </body>
+</html>

--- a/scroll-promises/window-methods/index.html
+++ b/scroll-promises/window-methods/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Scroll promises</title>
+    <title>Scroll promises — Window methods</title>
     <link href="style.css" rel="stylesheet" />
     <script defer src="index.js"></script>
   </head>

--- a/scroll-promises/window-methods/index.js
+++ b/scroll-promises/window-methods/index.js
@@ -6,21 +6,27 @@ const toolbar = document.querySelector("div");
 
 scrollBtn.addEventListener("click", async () => {
   toolbar.className = "fade-out";
-  await window.scroll(0, 1000);
-  console.log("Scroll finished");
+  const result = await window.scroll(0, 1000);
+  console.log(
+    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+  );
   toolbar.className = "fade-in";
 });
 
 scrollToBtn.addEventListener("click", async () => {
   toolbar.className = "fade-out";
-  await window.scrollTo(0, 0);
-  console.log("Scroll finished");
+  const result = await window.scrollTo(0, 0);
+  console.log(
+    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+  );
   toolbar.className = "fade-in";
 });
 
 scrollByBtn.addEventListener("click", async () => {
   toolbar.className = "fade-out";
-  await window.scrollBy(0, 200);
-  console.log("Scroll finished");
+  const result = await window.scrollBy(0, 200);
+  console.log(
+    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+  );
   toolbar.className = "fade-in";
 });

--- a/scroll-promises/window-methods/index.js
+++ b/scroll-promises/window-methods/index.js
@@ -9,33 +9,34 @@ function supportsScrollPromises() {
   return test instanceof Promise;
 }
 
+function isInterrupted(interrupted) {
+  console.log(`Scroll finished;${interrupted ? " " : " not "}interrupted`);
+  if (interrupted) {
+    alert("Scroll interrupted!");
+  }
+}
+
 const supports = supportsScrollPromises();
 
 if (supports) {
   scrollBtn.addEventListener("click", async () => {
     toolbar.className = "fade-out";
     const result = await window.scroll(0, 1000);
-    console.log(
-      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-    );
+    isInterrupted(result.interrupted);
     toolbar.className = "fade-in";
   });
 
   scrollToBtn.addEventListener("click", async () => {
     toolbar.className = "fade-out";
     const result = await window.scrollTo(0, 0);
-    console.log(
-      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-    );
+    isInterrupted(result.interrupted);
     toolbar.className = "fade-in";
   });
 
   scrollByBtn.addEventListener("click", async () => {
     toolbar.className = "fade-out";
     const result = await window.scrollBy(0, 200);
-    console.log(
-      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-    );
+    isInterrupted(result.interrupted);
     toolbar.className = "fade-in";
   });
 } else {

--- a/scroll-promises/window-methods/index.js
+++ b/scroll-promises/window-methods/index.js
@@ -4,29 +4,50 @@ const scrollByBtn = document.querySelector(".scrollby");
 
 const toolbar = document.querySelector("div");
 
-scrollBtn.addEventListener("click", async () => {
-  toolbar.className = "fade-out";
-  const result = await window.scroll(0, 1000);
-  console.log(
-    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-  );
-  toolbar.className = "fade-in";
-});
+function supportsScrollPromises() {
+  const test = window.scroll(0, 0);
+  return test instanceof Promise;
+}
 
-scrollToBtn.addEventListener("click", async () => {
-  toolbar.className = "fade-out";
-  const result = await window.scrollTo(0, 0);
-  console.log(
-    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-  );
-  toolbar.className = "fade-in";
-});
+const supports = supportsScrollPromises();
 
-scrollByBtn.addEventListener("click", async () => {
-  toolbar.className = "fade-out";
-  const result = await window.scrollBy(0, 200);
-  console.log(
-    `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
-  );
-  toolbar.className = "fade-in";
-});
+if (supports) {
+  scrollBtn.addEventListener("click", async () => {
+    toolbar.className = "fade-out";
+    const result = await window.scroll(0, 1000);
+    console.log(
+      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+    );
+    toolbar.className = "fade-in";
+  });
+
+  scrollToBtn.addEventListener("click", async () => {
+    toolbar.className = "fade-out";
+    const result = await window.scrollTo(0, 0);
+    console.log(
+      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+    );
+    toolbar.className = "fade-in";
+  });
+
+  scrollByBtn.addEventListener("click", async () => {
+    toolbar.className = "fade-out";
+    const result = await window.scrollBy(0, 200);
+    console.log(
+      `Scroll finished;${result.interrupted ? " " : " not "}interrupted`,
+    );
+    toolbar.className = "fade-in";
+  });
+} else {
+  scrollBtn.addEventListener("click", () => {
+    window.scroll(0, 1000);
+  });
+
+  scrollToBtn.addEventListener("click", () => {
+    window.scrollTo(0, 0);
+  });
+
+  scrollByBtn.addEventListener("click", () => {
+    window.scrollBy(0, 200);
+  });
+}

--- a/scroll-promises/window-methods/index.js
+++ b/scroll-promises/window-methods/index.js
@@ -1,0 +1,26 @@
+const scrollBtn = document.querySelector(".scroll");
+const scrollToBtn = document.querySelector(".scrollto");
+const scrollByBtn = document.querySelector(".scrollby");
+
+const toolbar = document.querySelector("div");
+
+scrollBtn.addEventListener("click", async () => {
+  toolbar.className = "fade-out";
+  await window.scroll(0, 1000);
+  console.log("Scroll finished");
+  toolbar.className = "fade-in";
+});
+
+scrollToBtn.addEventListener("click", async () => {
+  toolbar.className = "fade-out";
+  await window.scrollTo(0, 0);
+  console.log("Scroll finished");
+  toolbar.className = "fade-in";
+});
+
+scrollByBtn.addEventListener("click", async () => {
+  toolbar.className = "fade-out";
+  await window.scrollBy(0, 200);
+  console.log("Scroll finished");
+  toolbar.className = "fade-in";
+});

--- a/scroll-promises/window-methods/style.css
+++ b/scroll-promises/window-methods/style.css
@@ -1,0 +1,52 @@
+:root {
+  scroll-behavior: smooth;
+}
+
+body {
+  width: 50%;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+p {
+  font-family: sans-serif;
+  font-size: 1.3rem;
+  line-height: 1.5;
+}
+
+div {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  background: gray;
+  padding: 10px;
+}
+
+.fade-out {
+  animation: fade-out 0.3s linear both;
+}
+
+.fade-in {
+  animation: fade-in 0.3s linear both;
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
In Chrome 150 onwards, the standard `Element` and `Window` scroll methods now return promises. See https://chromestatus.com/feature/5082138340491264. This is particularly useful when a scroll operation is not instantaneous (e.g. you've got `scroll-behavior: smooth;` set on the scrolling container), and you want to programmatically react to the scroll operation finishing, for example, by updating the UI.

Affected methods are:

- `Element.scroll()`
- `Element.scrollBy()`
- `Element.scrollIntoView()`
- `Element.scrollTo()`
- `Window.scroll()`
- `Window.scrollBy()`
- `Window.scrollTo()`

This PR adds a couple of demos that show each promise-returning scroll method in use. I could do these as live examples, but I decided not to, as I don't want to add a huge standalone live example to all seven pages, with all of them doing nearly the same thing. I'd rather provide a couple of code snippets on each page and then link to the full example.