### PR TITLE
Add responsive iframe sizing demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,13 @@ Do not specify supported browsers and their versions in code comments or prose, 
 
 - The "resize-event" directory contains a basic demo to show how you can use the [resize event](https://developer.mozilla.org/docs/Web/API/Window/resize_event). Resize the browser window either by height or width to see the size of your current window. [Run the demo live](https://mdn.github.io/dom-examples/resize-event).
 
+- The "responsive-iframe-sizing" directory contains demos illustrating usage of the responsive iframe sizing features. See the [responsive iframe sizing README](responsive-iframe-sizing/README.md) for more information. Run the demos live: [Basic demo](https://mdn.github.io/dom-examples/responsive-iframe-sizing/basic/), [`requestResize()` demo](https://mdn.github.io/dom-examples/responsive-iframe-sizing/js-request-resize/).
+
 - The "screen-capture-api" directory contains demos to show typical usage of the [Screen Capture API](https://developer.mozilla.org/docs/Web/API/Screen_Capture_API) and [Screen Capture Extensions](https://developer.mozilla.org/docs/Web/API/Screen_Capture_extensions).
 
 - The "screenleft-screentop" directory contains a demo to show how you could use the [Window.screenLeft](https://developer.mozilla.org/docs/Web/API/Window/screenLeft) and [Window.screenTop](https://developer.mozilla.org/docs/Web/API/Window/screenTop) properties to draw a circle on a canvas that always stays in the same physical place on the screen when you move your browser window. [Run the demo live](https://mdn.github.io/dom-examples/screenleft-screentop/).
 
-- The "scroll-promises" directory contains demos illustrating usage of the promise-returning scroll methods (for example, `Element.scroll()`). See the [scroll promises README](scroll-promises/README.md) for more information.  Run the demos live: [Element methods](https://mdn.github.io/dom-examples/scroll-promises/element-methods/), [Window methods](https://mdn.github.io/dom-examples/scroll-promises/window-methods/).
+- The "scroll-promises" directory contains demos illustrating usage of the promise-returning scroll methods (for example, `Element.scroll()`). See the [scroll promises README](scroll-promises/README.md) for more information. Run the demos live: [Element methods](https://mdn.github.io/dom-examples/scroll-promises/element-methods/), [Window methods](https://mdn.github.io/dom-examples/scroll-promises/window-methods/).
 
 - The "scrolltooptions" directory contains a demo to show how you could use the [ScrollToOptions](https://developer.mozilla.org/docs/Web/API/ScrollToOptions) dictionary along with the [Window.ScrollTo()](https://developer.mozilla.org/docs/Web/API/Window/scrollTo) method to programmatically scroll a web page. [Run the demo live](https://mdn.github.io/dom-examples/scrolltooptions/).
 

--- a/responsive-iframe-sizing/README.md
+++ b/responsive-iframe-sizing/README.md
@@ -1,0 +1,12 @@
+# MDN responsive iframe sizing examples
+
+This set of examples demonstrates usage of the responsive iframe sizing features:
+
+- The CSS [`frame-sizing`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/frame-sizing) property
+- The [`Window.requestResize()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestResize) method
+- The [`<meta name="responsive-embedded-sizing">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/responsive-embedded-sizing) meta tag
+
+## Examples
+
+- [Basic example](basic/): Provides a basic example showing how the `frame-sizing` CSS property and `responsive-embedded-sizing` meta tag can be used to size an `<iframe>` to neatly contain its embedded content. [See the basic demo live](https://mdn.github.io/dom-examples/responsive-iframe-sizing/basic/).
+- [`requestResize()` example](js-request-resize/): Builds on the previous example, showing how the `requestResize()` method can be used to dynamically resize an `<iframe>` element to continue to neatly contain its embedded content, when the content size changes. [See the `requestResize()` demo live](https://mdn.github.io/dom-examples/responsive-iframe-sizing/js-request-resize/).

--- a/responsive-iframe-sizing/README.md
+++ b/responsive-iframe-sizing/README.md
@@ -3,8 +3,8 @@
 This set of examples demonstrates usage of the responsive iframe sizing features:
 
 - The CSS [`frame-sizing`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/frame-sizing) property
-- The [`Window.requestResize()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestResize) method
-- The [`<meta name="responsive-embedded-sizing">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/responsive-embedded-sizing) meta tag
+- The [`Window.requestResize()`](https://developer.mozilla.org/docs/Web/API/Window/requestResize) method
+- The [`<meta name="responsive-embedded-sizing">`](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/meta/name/responsive-embedded-sizing) meta tag
 
 ## Examples
 

--- a/responsive-iframe-sizing/basic/frame.html
+++ b/responsive-iframe-sizing/basic/frame.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="responsive-embedded-sizing" />
+    <title>frame</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+      }
+      html {
+        font-family: Arial, Helvetica, sans-serif;
+      }
+      div {
+        height: fit-content;
+        padding: 10px;
+        background-color: darkseagreen;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>This is my frame</h1>
+      <p>This is the content of my discontent.</p>
+      <p>This is some more content.</p>
+    </div>
+  </body>
+</html>

--- a/responsive-iframe-sizing/basic/frame.html
+++ b/responsive-iframe-sizing/basic/frame.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="responsive-embedded-sizing" />
-    <title>frame</title>
+    <title>Responsive iframes — basic example frame</title>
     <style>
       * {
         box-sizing: border-box;

--- a/responsive-iframe-sizing/basic/index.html
+++ b/responsive-iframe-sizing/basic/index.html
@@ -8,6 +8,21 @@
         frame-sizing: content-block-size;
         border: 2px solid gray;
       }
+
+      @supports not (frame-sizing: content-block-size) {
+        body::before {
+          content: "Your browser does not support responsive iframe sizing.";
+          font-family: sans-serif;
+          background-color: wheat;
+          padding: 1rem 0;
+          text-align: center;
+          padding: 1rem 0;
+
+          z-index: 1;
+          position: fixed;
+          inset: 40% 0 auto;
+        }
+      }
     </style>
   </head>
   <body>

--- a/responsive-iframe-sizing/basic/index.html
+++ b/responsive-iframe-sizing/basic/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Responsive iframes — basic example</title>
+    <style>
+      iframe {
+        frame-sizing: content-block-size;
+        border: 2px solid gray;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Responsive iframes — basic example</h1>
+
+    <iframe src="frame.html"></iframe>
+  </body>
+</html>

--- a/responsive-iframe-sizing/basic/index.html
+++ b/responsive-iframe-sizing/basic/index.html
@@ -16,8 +16,6 @@
           background-color: wheat;
           padding: 1rem 0;
           text-align: center;
-          padding: 1rem 0;
-
           z-index: 1;
           position: fixed;
           inset: 40% 0 auto;

--- a/responsive-iframe-sizing/js-request-resize/frame.html
+++ b/responsive-iframe-sizing/js-request-resize/frame.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="responsive-embedded-sizing" />
+    <title>frame</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+      }
+      html {
+        font-family: Arial, Helvetica, sans-serif;
+      }
+      div {
+        height: fit-content;
+        padding: 10px;
+        background-color: darkseagreen;
+      }
+    </style>
+  </head>
+  <body>
+    <div tabindex="0">
+      <h1>This is my frame</h1>
+      <p>This is the content of my discontent.</p>
+      <p>This is some more content.</p>
+    </div>
+    <script>
+      const divElem = document.querySelector("div");
+      divElem.addEventListener("click", addParagraph);
+      window.addEventListener("keypress", addParagraph);
+
+      function addParagraph() {
+        const para = document.createElement("p");
+        para.textContent = "New content.";
+        divElem.appendChild(para);
+        window.requestResize();
+      }
+    </script>
+  </body>
+</html>

--- a/responsive-iframe-sizing/js-request-resize/frame.html
+++ b/responsive-iframe-sizing/js-request-resize/frame.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="responsive-embedded-sizing" />
-    <title>frame</title>
+    <title>Responsive iframes — requestResize() frame</title>
     <style>
       * {
         box-sizing: border-box;

--- a/responsive-iframe-sizing/js-request-resize/frame.html
+++ b/responsive-iframe-sizing/js-request-resize/frame.html
@@ -30,7 +30,7 @@
     <script>
       const divElem = document.querySelector("div");
       divElem.addEventListener("click", addParagraph);
-      window.addEventListener("keypress", addParagraph);
+      window.addEventListener("keydown", addParagraph);
 
       function addParagraph() {
         const para = document.createElement("p");

--- a/responsive-iframe-sizing/js-request-resize/index.html
+++ b/responsive-iframe-sizing/js-request-resize/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Responsive iframes — requestResize()</title>
+    <style>
+      iframe {
+        frame-sizing: content-block-size;
+        border: 2px solid gray;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Responsive iframes — requestResize()</h1>
+
+    <iframe src="frame.html"></iframe>
+  </body>
+</html>

--- a/responsive-iframe-sizing/js-request-resize/index.html
+++ b/responsive-iframe-sizing/js-request-resize/index.html
@@ -8,6 +8,21 @@
         frame-sizing: content-block-size;
         border: 2px solid gray;
       }
+
+      @supports not (frame-sizing: content-block-size) {
+        body::before {
+          content: "Your browser does not support responsive iframe sizing.";
+          font-family: sans-serif;
+          background-color: wheat;
+          padding: 1rem 0;
+          text-align: center;
+          padding: 1rem 0;
+
+          z-index: 1;
+          position: fixed;
+          inset: 40% 0 auto;
+        }
+      }
     </style>
   </head>
   <body>

--- a/responsive-iframe-sizing/js-request-resize/index.html
+++ b/responsive-iframe-sizing/js-request-resize/index.html
@@ -16,8 +16,6 @@
           background-color: wheat;
           padding: 1rem 0;
           text-align: center;
-          padding: 1rem 0;
-
           z-index: 1;
           position: fixed;
           inset: 40% 0 auto;


### PR DESCRIPTION
Chrome 152 adds support for responsive iframe sizing; see https://chromestatus.com/feature/5108373464547328.

This relies on three new features:

- The CSS [`frame-sizing`](https://drafts.csswg.org/css-sizing-4/#propdef-frame-sizing) property
- The [`Window.requestResize`](https://drafts.csswg.org/css-sizing-4/#dom-window-requestresize) method
- The [`<meta name=responsive-embedded-sizing>`](https://drafts.csswg.org/css-sizing-4/#iframe-frame-sizing:~:text=If%20a-,%3Cmeta%20name%3Dresponsive%2Dembedded%2Dsizing%3E) meta tag

This PR adds examples to demonstrate all three features.
