### PR TITLE
Remove outdated comment on "recent browsers"

### DIFF
--- a/to-do-notifications/scripts/todo.js
+++ b/to-do-notifications/scripts/todo.js
@@ -80,7 +80,6 @@ window.onload = () => {
   // This event handles the event whereby a new version of the database needs to be created
   // Either one has not been created before, or a new version number has been submitted via the
   // window.indexedDB.open line above
-  //it is only implemented in recent browsers
   DBOpenRequest.onupgradeneeded = (event) => {
     db = event.target.result;
 


### PR DESCRIPTION
The comment was [added in 2013](https://github.com/mdn/dom-examples/blame/10f6250efb0c6ef1100f777e484ff469270d7d58/to-do-notifications/scripts/todo.js#L83), so is misleading today.