### PR TITLE
fix: remove incorrect screenLeft polyfill

### DIFF
--- a/screenleft-screentop/index.html
+++ b/screenleft-screentop/index.html
@@ -32,11 +32,6 @@
 
     let initialTop, initialLeft;
 
-    if(!window.screenLeft) {
-      window.screenLeft = window.screenX;
-      window.screenTop = window.screenY;
-    }
-
     initialLeft = window.screenLeft + canvasElem.offsetLeft;
     initialTop = window.screenTop + canvasElem.offsetTop;
 

--- a/screenleft-screentop/index.html
+++ b/screenleft-screentop/index.html
@@ -30,10 +30,8 @@
 
     const pElem = document.querySelector('p');
 
-    let initialTop, initialLeft;
-
-    initialLeft = window.screenLeft + canvasElem.offsetLeft;
-    initialTop = window.screenTop + canvasElem.offsetTop;
+    let initialLeft = window.screenLeft + canvasElem.offsetLeft;
+    let initialTop = window.screenTop + canvasElem.offsetTop;
 
     function positionElem() {
       let newLeft = window.screenLeft + canvasElem.offsetLeft;


### PR DESCRIPTION
The example doesn't move the circle if the window starts with `screenLeft=0`, as noticed in https://github.com/mdn/content/pull/45097.

Remove the incorrect feature detection. Every browser supports `screenLeft` anyway, and whenever this fallback runs it assigns static values rather than live aliases, so it is never useful.
