### PR TITLE
Fix broken popover hint example

### DIFF
--- a/popover-api/popover-hint/index.css
+++ b/popover-api/popover-hint/index.css
@@ -47,6 +47,7 @@ body {
   border-radius: 4px;
   background: #eee;
   flex: 1;
+  position: relative; /* 1 */
 }
 
 #button-bar button:hover,
@@ -55,18 +56,17 @@ body {
 }
 
 #button-bar button:active {
-  box-shadow: inset 1px 1px 2px #333, inset -1px -1px 2px #eee;
+  box-shadow:
+    inset 1px 1px 2px #333,
+    inset -1px -1px 2px #eee;
 }
 
 /* Styling auto popovers */
 
 [popover="auto"] {
-  inset: unset;
   position: absolute;
-  bottom: calc(anchor(top) + 20px);
-  justify-self: anchor-center;
-  margin: 0;
-
+  position-area: top;
+  margin-bottom: 15px;
   width: 200px;
   text-align: center;
   padding: 8px;
@@ -94,17 +94,19 @@ body {
 }
 
 [popover="auto"] button:active {
-  box-shadow: inset 1px 1px 2px #333, inset -1px -1px 2px #eee;
+  box-shadow:
+    inset 1px 1px 2px #333,
+    inset -1px -1px 2px #eee;
 }
 
 /* Styling hint popovers */
 
 [popover="hint"] {
-  inset: unset;
   position: absolute;
+  position-anchor: auto;
+  margin: 0; /* reset popover default */
   top: calc(anchor(bottom) + 5px);
   justify-self: anchor-center;
-  margin: 0;
 
   padding: 8px;
   border-radius: 6px;


### PR DESCRIPTION
While fixing https://github.com/mdn/content/issues/45515 (see https://github.com/mdn/content/pull/45550), I noticed that my popover=hint example was broken: https://mdn.github.io/dom-examples/popover-api/popover-hint/. The auto and hint popovers now all appear in the top-left of the viewport.

This PR fixes the example. For the auto popovers, I replaced the `anchor()`/`anchor-center` positioning with `position-area` positioning. For the hint popovers, I kept the `anchor()`/`anchor-center` positioning, but made sure to include a margin reset and included `position-anchor: auto;` because it seems like this is now needed to opt-in to the association in this case.

It now works fine in Chromiums and Fx. In Safari it works, except that the auto popovers move to the bottom of the screen when you are not hovering over a popover control (seems like a bug in Safari to me). This is much better support than it used to be; it used to be broken in both Saf and Fx.

Fixes https://github.com/mdn/dom-examples/pull/396